### PR TITLE
fix: restore allowScripts whitelist for npm 11 installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,5 +209,16 @@
     "markdown-it": "15.0.0",
     "node": "22.22.3",
     "ws": "^8.21.3"
+  },
+  "allowScripts": {
+    "node@22.22.3": true,
+    "@deepseek-ai/dsh-subprocess-local@0.1.0-rc.6": true,
+    "esbuild@0.25.12": true,
+    "node-pty@1.1.0": true,
+    "koffi@3.1.4": true,
+    "keytar@7.9.0": true,
+    "protobufjs@7.6.5": true,
+    "@vscode/vsce-sign@2.0.9": true,
+    "@google/genai@1.52.0": true
   }
 }


### PR DESCRIPTION
## Summary

npm 11 (current npm) **blocks dependency install scripts by default** unless the package is allowlisted via the \llowScripts\ field in \package.json\. The whitelist added in the 0.4.1 Windows support PR (#1) was dropped by the 0.4.2 release commit, which breaks \
pm install\ on Windows for native dependencies (\
ode-pty\, \koffi\, \keytar\, \protobufjs\, \@vscode/vsce-sign\, etc.) — their install scripts are silently skipped and the native binaries never get built.

## What this does

Restores the exact \llowScripts\ entries from the merged 0.4.1 PR:

- \
ode@22.22.3\ — postinstall unpack of the bundled Node binary
- \@deepseek-ai/dsh-subprocess-local@0.1.0-rc.6\, \
ode-pty@1.1.0\, \koffi@3.1.4\, \keytar@7.9.0\, \protobufjs@7.6.5\, \@vscode/vsce-sign@2.0.9\, \@google/genai@1.52.0\ — native/postinstall builds

## Compatibility

\llowScripts\ is **inert on npm < 11** (npm 10 and earlier ignore it), so this is safe for all environments. On npm 11 it makes \
pm install\ work on Windows without manual \
pm install-scripts approve\.

## Tested

\
pm install\ on Windows (npm 11.18) now completes and produces working native modules (\
ode-pty\ conpty, \koffi\ win32-x64, \keytar\).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation settings to allow required setup scripts for supported development and integration tools.
  * Improved compatibility with build tooling, terminal features, credential storage, signing, and AI-related integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->