### PR TITLE
feat: detachable chat panel window + fix Windows gateway boot path

### DIFF
--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -5,6 +5,7 @@
   "DeepSeek API Key was saved to the local Harness credential store.": "DeepSeek API Key 已保存到本地 Harness 凭据库。",
   "Clear": "清除",
   "Clear the DeepSeek API Key from the local Harness credential store?": "确定要从本地 Harness 凭据库清除 DeepSeek API Key 吗？",
+  "DeepSeek Harness": "DeepSeek Harness",
   "DeepSeek Harness: {0}": "DeepSeek Harness：{0}",
   "Create Harness Goal": "创建 Harness Goal",
   "Harness will pursue this goal until it is completed, paused, or reaches its round limit.": "Harness 会持续推进该目标，直到完成、暂停或达到轮次限制。",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
-{
+﻿{
   "name": "deepseek-harness-for-vscode",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-for-vscode",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh": "0.1.0-rc.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deepseek-harness-for-vscode",
   "displayName": "DeepSeek Harness for Visual Studio Code",
   "description": "%extension.description%",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "publisher": "skymecode",
   "license": "MIT",
@@ -51,6 +51,11 @@
         "icon": "$(comment-discussion)"
       },
       {
+        "command": "deepseekHarness.openChatWindow",
+        "title": "%command.openChatWindow%",
+        "icon": "$(new-window)"
+      },
+      {
         "command": "deepseekHarness.reloadRuntime",
         "title": "%command.reloadRuntime%",
         "icon": "$(refresh)"
@@ -88,6 +93,11 @@
     },
     "menus": {
       "view/title": [
+        {
+          "command": "deepseekHarness.openChatWindow",
+          "when": "view == deepseekHarness.chatView",
+          "group": "navigation@3"
+        },
         {
           "command": "deepseekHarness.reloadRuntime",
           "when": "view == deepseekHarness.chatView",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
   "extension.description": "A native DeepSeek Harness coding agent for VS Code. Uses the local Harness Gateway without requiring a separate deployment.",
   "command.openChat": "DeepSeek Harness: Open Workbench",
+  "command.openChatWindow": "DeepSeek Harness: Open Workbench in New Window",
   "command.reloadRuntime": "DeepSeek Harness: Reload Workbench",
   "command.setApiKey": "DeepSeek Harness: Set API Key",
   "command.clearApiKey": "DeepSeek Harness: Clear API Key",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,6 +1,7 @@
 {
   "extension.description": "原生 DeepSeek Harness VS Code 编码 Agent，使用本地 Harness Gateway，无需单独部署。",
   "command.openChat": "DeepSeek Harness: 打开工作台",
+  "command.openChatWindow": "DeepSeek Harness: 在新窗口打开工作台",
   "command.reloadRuntime": "DeepSeek Harness: 重新加载工作台",
   "command.setApiKey": "DeepSeek Harness: 设置 API Key",
   "command.clearApiKey": "DeepSeek Harness: 清除 API Key",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       webviewOptions: { retainContextWhenHidden: true },
     }),
     vscode.commands.registerCommand('deepseekHarness.openChat', focusWorkbench),
+    vscode.commands.registerCommand('deepseekHarness.openChatWindow', () => provider.openPanel()),
     vscode.commands.registerCommand('deepseekHarness.reloadRuntime', () => provider.refresh()),
     vscode.commands.registerCommand('deepseekHarness.setApiKey', setApiKey),
     vscode.commands.registerCommand('deepseekHarness.clearApiKey', async () => {

--- a/src/runtime/runtime-overlay.ts
+++ b/src/runtime/runtime-overlay.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import type { HarnessConfiguration } from '../config/configuration.js'
 
 /** Generates a trusted overlay from validated VS Code settings. */
@@ -12,7 +13,7 @@ export function renderOverlay(configuration: HarnessConfiguration, gatewayPlugin
     # Keep the official API transport alive by providing only the bind facts
     # consumed by dsh-client-connection. No HTTP fallback is registered.
     - id: vscode-gateway-runtime
-      name: ${JSON.stringify(gatewayPluginPath)}
+      name: ${JSON.stringify(pathToFileURL(gatewayPluginPath).href)}
       config:
         printUrl: true
 

--- a/src/ui/workbench-view-provider.ts
+++ b/src/ui/workbench-view-provider.ts
@@ -25,8 +25,10 @@ export interface WorkbenchViewActions {
 /** Native Codex/Cline-style workbench. No Harness page or iframe is embedded. */
 export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   static readonly viewType = 'deepseekHarness.chatView'
+  static readonly panelViewType = 'deepseekHarness.chatPanel'
 
   private view: vscode.WebviewView | undefined
+  private panel: vscode.WebviewPanel | undefined
   private readonly subscriptions: vscode.Disposable[]
   private publishing: Promise<void> | undefined
   private publishPending = false
@@ -46,9 +48,9 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
     }), connectionSettings.onDidChange(() => {
       void this.publishState().catch(() => undefined)
     }), pluginCenter.onDidChange((snapshot) => {
-      void this.view?.webview.postMessage({ type: 'pluginState', snapshot })
+      void this.postToHosts({ type: 'pluginState', snapshot })
     }), editorSelection.onDidChange((selection) => {
-      void this.view?.webview.postMessage({ type: 'editorSelection', selection })
+      void this.postToHosts({ type: 'editorSelection', selection })
     })]
   }
 
@@ -77,6 +79,46 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
 
   dispose(): void {
     for (const subscription of this.subscriptions) subscription.dispose()
+    this.panel?.dispose()
+  }
+
+  /** Opens the workbench in a detachable editor-area panel, like Claude Code. */
+  openPanel(): void {
+    if (this.panel !== undefined) {
+      this.panel.reveal()
+      return
+    }
+    const panel = vscode.window.createWebviewPanel(
+      WorkbenchViewProvider.panelViewType,
+      vscode.l10n.t('DeepSeek Harness'),
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(this.extensionUri, 'media'),
+          vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview'),
+        ],
+      },
+    )
+    panel.webview.html = this.html(panel.webview)
+    panel.webview.onDidReceiveMessage((message: unknown) => {
+      void this.handleMessage(message).catch((cause: unknown) => {
+        const detail = cause instanceof Error ? cause.message : String(cause)
+        void vscode.window.showErrorMessage(vscode.l10n.t('DeepSeek Harness: {0}', detail))
+      })
+    })
+    panel.onDidDispose(() => {
+      if (this.panel === panel) this.panel = undefined
+    })
+    this.panel = panel
+    void this.publishState().catch(() => undefined)
+    void this.publishEditorSelection()
+  }
+
+  private postToHosts(message: unknown): void {
+    void this.view?.webview.postMessage(message)
+    void this.panel?.webview.postMessage(message)
   }
 
   private publishState(): Promise<void> {
@@ -98,7 +140,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
       this.publishPending = false
       const state = await this.gateway.snapshot()
       const connectionSettings = this.connectionSettings.state
-      await this.view?.webview.postMessage({
+      await this.postToHosts({
         type: 'state',
         state,
         configuration: this.configuration.get(),
@@ -136,7 +178,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
       }
       case 'testConnection': {
         const result = await this.actions.testConnection(settingsInput(value))
-        await this.view?.webview.postMessage({ type: 'connectionTestResult', ...result })
+        await this.postToHosts({ type: 'connectionTestResult', ...result })
         break
       }
       case 'openSettings':
@@ -164,7 +206,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
       case 'searchSessions': {
         const query = typeof value.query === 'string' ? value.query : ''
         const results = await this.gateway.searchSessions(query)
-        await this.view?.webview.postMessage({ type: 'searchResults', query, results })
+        await this.postToHosts({ type: 'searchResults', query, results })
         break
       }
       case 'selectSession':
@@ -220,7 +262,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
         const query = typeof value.query === 'string' ? value.query.slice(0, 200) : ''
         const requestId = numberValue(value.requestId)
         const files = await this.workspaceFiles.search(query)
-        await this.view?.webview.postMessage({ type: 'workspaceFileSuggestions', query, requestId, files })
+        await this.postToHosts({ type: 'workspaceFileSuggestions', query, requestId, files })
         break
       }
       case 'openFile': {
@@ -232,7 +274,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
       }
       case 'attachSelection': {
         const selection = this.editorSelection.current()
-        await this.view?.webview.postMessage({ type: 'editorSelection', selection })
+        await this.postToHosts({ type: 'editorSelection', selection })
         if (selection === undefined) {
           void vscode.window.showInformationMessage(vscode.l10n.t('Select code in an editor first.'))
         }
@@ -283,7 +325,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
   }
 
   private async publishEditorSelection(): Promise<void> {
-    await this.view?.webview.postMessage({
+    await this.postToHosts({
       type: 'editorSelection',
       selection: this.editorSelection.current(),
     })

--- a/src/ui/workbench-view-provider.ts
+++ b/src/ui/workbench-view-provider.ts
@@ -112,6 +112,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
       if (this.panel === panel) this.panel = undefined
     })
     this.panel = panel
+    void this.gateway.start()
     void this.publishState().catch(() => undefined)
     void this.publishEditorSelection()
   }

--- a/test/runtime-overlay.test.ts
+++ b/test/runtime-overlay.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { renderOverlay } from '../src/runtime/runtime-overlay.js'
 
@@ -18,7 +19,7 @@ describe('Harness Web profile overlay', () => {
     expect(overlay).toContain('id: web-runtime')
     expect(overlay).toContain('disabled: true')
     expect(overlay).toContain('id: vscode-gateway-runtime')
-    expect(overlay).toContain('name: "/extension/dist/runtime/gateway-runtime.mjs"')
+    expect(overlay).toContain(`name: ${JSON.stringify(pathToFileURL('/extension/dist/runtime/gateway-runtime.mjs').href)}`)
     expect(overlay).toContain('reasoningEffort: max')
     expect(overlay).toContain('provider: "packycode"')
     expect(overlay).toContain('model: deepseek-v4-pro')


### PR DESCRIPTION
## 变更内容 / What's in this PR

### 1. Chat 可独立拖出窗口（类似 Claude Code）
- `src/ui/workbench-view-provider.ts`：新增 `openPanel()`，用 `vscode.window.createWebviewPanel` 在编辑器区打开 Harness 工作台（`ViewColumn.Beside`），可像 Claude Code 一样拖出为独立窗口；新增 `postToHosts()`，侧边栏视图与面板共享同一 Gateway 状态并实时同步。
- `src/extension.ts`：注册命令 `deepseekHarness.openChatWindow`。
- `package.json`：新增命令与 chat 视图标题栏"新窗口"按钮（`$(new-window)`，group `navigation@3`）；版本升至 0.4.7。
- `package.nls.json` / `package.nls.zh-cn.json` / `l10n/bundle.l10n.zh-cn.json`：中英文命令名与面板标题翻译。

### 2. 修复 Windows 启动崩溃（issue #5）
- `src/runtime/runtime-overlay.ts`：`vscode-gateway-runtime` 的 loader entry `name` 改用 `pathToFileURL(gatewayPluginPath).href` 生成 `file://` URL。此前写入裸 `c:\...` 路径，Node ESM loader 在 Windows 上抛 `ERR_UNSUPPORTED_ESM_URL_SCHEME (Received protocol 'c:')`，导致 Gateway 启动即退出（code=1）、UI 显示 "Connection failed"，且与 API Key 无关。
- `test/runtime-overlay.test.ts`：断言更新为平台无关的 `file://` 期望值。

## 验证 / Verification
- `npm run package` 全流程通过：`tsc --noEmit` 无错误，vitest **103/103** 通过。
- 用打包产物内的运行时端到端启动成功：`dsh gateway: http://127.0.0.1:PORT`。
- 在 Windows 11 + VS Code 实测：安装 0.4.7 后启动正常；面板可从活动栏视图或命令 `DeepSeek Harness: Open Workbench in New Window` 打开，并拖出为独立窗口。

## 相关 / Related
- Fixes Windows boot failure described in issue #5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to open the Harness workbench in a separate editor window.
  * The detached workbench stays synchronized with connection status, search results, workspace suggestions, and selections.

* **Localization**
  * Added Chinese translations for the new command and DeepSeek Harness label.

* **Bug Fixes**
  * Improved runtime plugin loading by using file URLs for compatibility.

* **Chores**
  * Updated the extension version to 0.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->