### PR TITLE
fix: provider removal safety, narrow-panel layout, and off-reasoning

### DIFF
--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -195,6 +195,7 @@
   "Name": "名称",
   "Provider name": "提供商名称",
   "Add provider…": "添加提供商…",
+  "Confirm removal": "确认移除",
   "API Key": "API Key",
   "Enter a new API Key": "输入新的 API KEY",
   "Configured — leave blank to keep it": "已配置；留空可保留现有密钥",

--- a/media/chat.css
+++ b/media/chat.css
@@ -88,6 +88,7 @@ body.vscode-dark .brand-logo, body.vscode-high-contrast .brand-logo { filter: in
 .key-banner button, .primary-button { color: var(--vscode-button-foreground); background: var(--vscode-button-background); }
 .primary-button:hover { background: var(--vscode-button-hoverBackground); }
 .secondary-button { color: var(--vscode-button-secondaryForeground); background: var(--vscode-button-secondaryBackground); }
+.secondary-button.danger { color: var(--vscode-button-foreground); background: var(--vscode-inputValidation-errorBackground, #f14c4c); border-color: var(--vscode-inputValidation-errorBorder, #f14c4c); }
 
 .history-panel {
   position: fixed;
@@ -227,8 +228,8 @@ body.vscode-dark .brand-logo, body.vscode-high-contrast .brand-logo { filter: in
 body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: invert(1) drop-shadow(0 8px 18px color-mix(in srgb, #4d6bfe 26%, transparent)); }
 .empty-state h2 { margin: 15px 0 6px; font-size: 15px; }
 .empty-state p { max-width: 270px; margin: 0; color: var(--vscode-descriptionForeground); font-size: 11px; line-height: 1.5; }
-.messages { display: grid; gap: 12px; }
-.message { min-width: 0; display: grid; gap: 4px; }
+.messages { display: grid; grid-template-columns: minmax(0, 1fr); gap: 12px; }
+.message { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr); gap: 4px; }
 .message.user { justify-items: end; }
 .message-label { color: var(--vscode-descriptionForeground); font-size: 10px; }
 .message.user .message-label { padding-right: 5px; }

--- a/src/gateway/harness-gateway-service.ts
+++ b/src/gateway/harness-gateway-service.ts
@@ -155,7 +155,7 @@ export class HarnessGatewayService implements vscode.Disposable {
   }
 
   async snapshot(): Promise<HarnessWorkbenchState> {
-    const hasApiKey = this.connectionSettings.hasConfiguredProvider
+    const hasApiKey = this.connectionSettings.hasConfiguredProvider()
     const summaries = this.orderedSummaries().map((summary) => sessionListItem(summary, this.labels))
     const activeSummary = this.activeSessionId === undefined ? undefined : this.summaries.get(this.activeSessionId)
     const projected = projectConversation(this.entries, this.labels)

--- a/src/runtime/runtime-overlay.ts
+++ b/src/runtime/runtime-overlay.ts
@@ -3,7 +3,6 @@ import type { HarnessConfiguration } from '../config/configuration.js'
 
 /** Generates a trusted overlay from validated VS Code settings. */
 export function renderOverlay(configuration: HarnessConfiguration, gatewayPluginPath: string): string {
-  const thinking = configuration.reasoningEffort === 'off' ? 'disabled' : 'enabled'
   const webSearchRow = configuration.webSearch ? '' : `- id: web-search-deepseek
   disabled: true
 
@@ -23,7 +22,6 @@ export function renderOverlay(configuration: HarnessConfiguration, gatewayPlugin
 
 ${webSearchRow}- id: llm-deepseek
   config:
-    thinking: ${thinking}
     reasoningEffort: ${configuration.reasoningEffort}
 
 - id: agent-default-model

--- a/src/services/connection-settings-service.ts
+++ b/src/services/connection-settings-service.ts
@@ -62,7 +62,7 @@ export class ConnectionSettingsService {
     return this.client !== undefined
   }
 
-  get hasConfiguredProvider(): boolean {
+  hasConfiguredProvider(): boolean {
     return this.stateValue.providers.some((provider) => provider.apiKeyConfigured)
   }
 
@@ -178,13 +178,17 @@ export class ConnectionSettingsService {
     const client = this.requireClient()
     const namespace = await this.namespace(PI_AI_SETTINGS_NS)
     const ref = credentialRefForProfile(valueAt(namespace.value, ['providers', provider]), provider)
-    const credential = valueOf(await client.credentials.describe({ refs: [ref] })).credentials[ref]
-    if (credential?.configured === true && credential.writable) valueOf(await client.credentials.unset({ ref }))
+    // Delete the profile first: if this write fails on a stale revision, the
+    // credential is still intact, so the user never loses a key for a provider
+    // that still exists. A credential unset that fails afterwards leaves only
+    // an invisible orphan key, which is safe.
     valueOf(await client.settings.mutate({
       ns: PI_AI_SETTINGS_NS,
       ops: [{ op: 'unset', path: ['providers', provider] }],
       expectedRevision: namespace.revision,
     }))
+    const credential = valueOf(await client.credentials.describe({ refs: [ref] })).credentials[ref]
+    if (credential?.configured === true && credential.writable) valueOf(await client.credentials.unset({ ref }))
     await this.refresh()
   }
 

--- a/src/webview/connection-settings/component.ts
+++ b/src/webview/connection-settings/component.ts
@@ -42,6 +42,7 @@ export function createConnectionSettingsComponent(options: ConnectionSettingsCom
   let state: ConnectionSettingsState = { writable: false, providers: [] }
   let defaultProvider = DEEPSEEK_OFFICIAL_PROVIDER
   let activeProvider: string | undefined
+  let confirmingRemove = false
 
   const selected = (): ConnectionProviderView | undefined => state.providers.find((item) => item.id === providerSelect.value)
   const input = (): Record<string, unknown> => ({
@@ -76,6 +77,9 @@ export function createConnectionSettingsComponent(options: ConnectionSettingsCom
     nameField.classList.toggle('hidden', official)
     remove.classList.toggle('hidden', official || creating || provider?.removable !== true)
     remove.disabled = provider === undefined || provider.id === activeProvider
+    confirmingRemove = false
+    remove.textContent = t('remove')
+    remove.classList.remove('danger')
     name.value = provider?.name ?? ''
     name.disabled = !state.writable || (!creating && provider === undefined)
     baseUrl.value = provider?.baseUrl ?? (official ? 'https://api.deepseek.com' : '')
@@ -137,6 +141,13 @@ export function createConnectionSettingsComponent(options: ConnectionSettingsCom
   remove.addEventListener('click', () => {
     const provider = selected()
     if (provider === undefined || remove.disabled) return
+    if (!confirmingRemove) {
+      confirmingRemove = true
+      remove.textContent = t('confirmRemove')
+      remove.classList.add('danger')
+      return
+    }
+    confirmingRemove = false
     post('removeProvider', { provider: provider.id })
     panel.classList.add('hidden')
   })

--- a/src/webview/localization.ts
+++ b/src/webview/localization.ts
@@ -64,6 +64,7 @@ export const ENGLISH_WEBVIEW_MESSAGES = {
   providerName: 'Name',
   providerNamePlaceholder: 'Provider name',
   addProvider: 'Add provider…',
+  confirmRemove: 'Confirm removal',
   apiKey: 'API Key',
   apiKeyPlaceholder: 'Enter a new API Key',
   apiKeyKeepPlaceholder: 'Configured — leave blank to keep it',

--- a/test/connection-settings-service.test.ts
+++ b/test/connection-settings-service.test.ts
@@ -183,7 +183,7 @@ describe('ConnectionSettingsService', () => {
     })).rejects.toThrow('custom provider')
   })
 
-  it('removes the managed credential before removing a custom profile', async () => {
+  it('removes the custom profile and its managed credential', async () => {
     const harness = fakeHarness({
       packycode: {
         displayName: 'PackyCode',
@@ -201,6 +201,29 @@ describe('ConnectionSettingsService', () => {
     expect(harness.document.credentials.PROVIDER_PACKYCODE_API_KEY).toBeUndefined()
     expect(harness.document.piAi.value.providers.packycode).toBeUndefined()
     expect(service.state.providers.map((provider) => provider.id)).toEqual(['deepseek-official'])
+  })
+
+  it('keeps the credential when the profile deletion is rejected', async () => {
+    const harness = fakeHarness({
+      packycode: {
+        displayName: 'PackyCode',
+        baseURL: 'https://relay.example/v1',
+        api: 'openai-completions',
+        apiKeyEnv: 'PROVIDER_PACKYCODE_API_KEY',
+        models: deepSeekModels(),
+      },
+    }, { PROVIDER_PACKYCODE_API_KEY: 'stored-secret' })
+    const service = serviceFor()
+    await service.connect(harness.client as never)
+
+    // Simulate a stale-revision write: the profile deletion is refused before
+    // the credential is ever touched.
+    const settings = harness.client.settings as { mutate: () => Promise<unknown> }
+    settings.mutate = () => Promise.resolve({ rpcId: 'test', result: { ok: false, error: { message: 'settings-conflict' } } })
+
+    await expect(service.remove('packycode')).rejects.toThrow('settings-conflict')
+    expect(harness.document.credentials.PROVIDER_PACKYCODE_API_KEY).toBe('stored-secret')
+    expect(harness.document.piAi.value.providers.packycode).toBeDefined()
   })
 
   it('finishes migrating a legacy key when its provider profile already exists', async () => {

--- a/test/runtime-overlay.test.ts
+++ b/test/runtime-overlay.test.ts
@@ -48,7 +48,7 @@ describe('Harness Web profile overlay', () => {
     expect(() => load(overlay)).not.toThrow()
   })
 
-  it('disables thinking and safely quotes provider ids', () => {
+  it('passes the off reasoning effort through and safely quotes provider ids', () => {
     const overlay = renderOverlay({
       model: 'deepseek-v4-flash',
       reasoningEffort: 'off',
@@ -58,7 +58,8 @@ describe('Harness Web profile overlay', () => {
       webSearch: true,
       autoAttachSelection: false,
     }, 'C:\\Extensions\\DeepSeek Harness\\gateway-runtime.mjs')
-    expect(overlay).toContain('thinking: disabled')
+    expect(overlay).toContain('reasoningEffort: off')
+    expect(overlay).not.toContain('thinking:')
     expect(overlay).toContain('provider: "custom: route"')
     expect(overlay).toContain('defaultPreset: read-only')
     expect(() => load(overlay)).not.toThrow()


### PR DESCRIPTION
本 PR 包含三类修复/优化：

## 1. 连接设置：提供商移除的安全性与体验

- 修复移除自定义提供商的执行顺序：先删除 provider 配置、再删除凭据。若配置写入因 revision 冲突被拒绝，凭据仍保留，避免用户为仍存在的提供商丢失 API Key。
- 移除确认从原生模态框改为 webview 内两步确认：点「移除」→ 按钮变红显示「确认移除」→ 再点一次才真正删除，降低误触。
- 顶部「请配置 API Key」引导横幅改为「任一提供商已配置 Key 即隐藏」，更贴合其首次引导的定位（此前按当前提供商判断会误报）。

## 2. Windows 窄面板：用户消息被裁剪

- 为 `.messages` / `.message` 网格显式声明 `grid-template-columns: minmax(0, 1fr)`，避免隐式 `auto` 列随内容撑宽，导致右对齐的用户气泡在窄面板下被推出可视区并被 `overflow-x: hidden` 裁剪。macOS / Windows 行为一致，不引入新的视觉变化。

## 3. 推理等级「关」档位锁定

- 移除 overlay 中 `thinking: disabled` 的下发。此前当推理等级为 off 时，会把 `llm-deepseek` 的 `thinking` 配置成 `disabled`，导致适配器只上报 `off` 一个档位（`OFF_ONLY_REASONING_EFFORTS`），推理滑杆被锁死、无法切回低/高/超高。
- 适配器本身已在请求层把 `off` 正确翻译为 `thinking: disabled`（`resolveThinking`），配置层无需再设置；移除后滑杆恢复四档（关/低/高/超高），off 的实际行为不变。

## 测试

- 新增「profile 删除被拒绝时凭据保留」用例（`test/connection-settings-service.test.ts`）。
- 更新 overlay 用例：验证 `reasoningEffort: off` 仍透传、且不再下发 `thinking`（`test/runtime-overlay.test.ts`）。
- 本地 `npm run compile` 通过，`npm test` 28 个文件 113 用例全绿。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a two-step confirmation process before removing a configured provider.
  - Added Simplified Chinese localization for the removal confirmation message.
  - Reasoning effort settings now pass through accurately, including the disabled state.

- **Bug Fixes**
  - Provider credentials are preserved if profile removal fails.
  - Improved message layout to prevent content from exceeding available width.
  - Added clearer danger styling for destructive actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->