### PR TITLE
fix: update allowScripts koffi entry to 3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@deepseek-ai/dsh-subprocess-local@0.1.0-rc.7": true,
     "esbuild@0.25.12": true,
     "node-pty@1.2.0-beta.15": true,
-    "koffi@3.1.4": true,
+    "koffi@3.1.5": true,
     "keytar@7.9.0": true,
     "protobufjs@7.6.5": true,
     "@vscode/vsce-sign@2.0.9": true,


### PR DESCRIPTION
## Summary

npm 11 resolves `koffi` to **3.1.5** (from the `^3.1.0` range), but the `allowScripts` whitelist in `package.json` still lists **3.1.4**. On a clean `npm install` with npm 11, koffi's install script (`node ./cnoke.cjs`) is silently skipped, leaving the native binary missing and the extension failing to load koffi at runtime.

## Change

One-line update: `koffi@3.1.4` → `koffi@3.1.5` in `allowScripts`.

## Verification

- `node -e "const k = require('koffi'); k.version"` resolves to 3.1.5 after install.
- Inert on npm < 11.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the allowed `koffi` package version to 3.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->