### PR TITLE
feat: collapse the models and DSH mode groups into folders

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -626,7 +626,14 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 #configuration-source:disabled { opacity: .65; }
 .configuration-panel-scroll { min-height: 0; padding: 0 8px 8px; display: grid; gap: 7px; overflow-y: auto; overscroll-behavior: contain; }
 .configuration-group { display: grid; gap: 4px; }
-.configuration-group h3 { margin: 0; padding: 2px 5px; color: var(--vscode-descriptionForeground); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; }
+.configuration-group h3 { margin: 0; }
+.configuration-group-toggle { width: 100%; padding: 2px 5px; display: flex; align-items: center; gap: 5px; color: var(--vscode-descriptionForeground); background: transparent; border: 0; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; text-align: left; cursor: pointer; }
+.configuration-group-toggle:hover { color: var(--vscode-foreground); background: var(--vscode-toolbar-hoverBackground); }
+.configuration-group-chevron { flex: none; transition: transform 140ms ease; }
+.configuration-group:not(.collapsed) .configuration-group-chevron { transform: rotate(90deg); }
+.configuration-group.collapsed .configuration-options { display: none; }
+.configuration-group-current { min-width: 0; margin-left: auto; overflow: hidden; color: var(--vscode-descriptionForeground); font-weight: 400; text-transform: none; letter-spacing: 0; text-overflow: ellipsis; white-space: nowrap; }
+.configuration-group:not(.collapsed) .configuration-group-current { display: none; }
 .configuration-options { display: grid; gap: 2px; }
 .configuration-model-group .configuration-options { grid-template-columns: 1fr; gap: 4px; }
 .configuration-model-group-header {

--- a/src/ui/workbench-view-provider.ts
+++ b/src/ui/workbench-view-provider.ts
@@ -537,12 +537,24 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
             <button id="configuration-close" class="icon-button compact" type="button" title="${text('configurationClose')}" aria-label="${text('configurationClose')}">×</button>
           </header>
           <div class="configuration-panel-scroll">
-            <section class="configuration-group configuration-model-group" aria-labelledby="configuration-models-label">
-              <h3 id="configuration-models-label">${text('configurationModels')}</h3>
+            <section class="configuration-group configuration-model-group collapsed" aria-labelledby="configuration-models-label">
+              <h3 id="configuration-models-label">
+                <button id="configuration-models-toggle" class="configuration-group-toggle" type="button" aria-expanded="false" aria-controls="configuration-models">
+                  <span class="configuration-group-chevron" aria-hidden="true">›</span>
+                  <span>${text('configurationModels')}</span>
+                  <span id="configuration-models-current" class="configuration-group-current"></span>
+                </button>
+              </h3>
               <div id="configuration-models" class="configuration-options" role="listbox"></div>
             </section>
-            <section class="configuration-group" aria-labelledby="configuration-modes-label">
-              <h3 id="configuration-modes-label">${text('configurationModes')}</h3>
+            <section class="configuration-group collapsed" aria-labelledby="configuration-modes-label">
+              <h3 id="configuration-modes-label">
+                <button id="configuration-presets-toggle" class="configuration-group-toggle" type="button" aria-expanded="false" aria-controls="configuration-presets">
+                  <span class="configuration-group-chevron" aria-hidden="true">›</span>
+                  <span>${text('configurationModes')}</span>
+                  <span id="configuration-presets-current" class="configuration-group-current"></span>
+                </button>
+              </h3>
               <div id="configuration-presets" class="configuration-options" role="listbox"></div>
             </section>
           </div>

--- a/src/webview/composer-configuration/component.ts
+++ b/src/webview/composer-configuration/component.ts
@@ -42,6 +42,10 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
   private readonly source: HTMLSelectElement
   private readonly models: HTMLElement
   private readonly presets: HTMLElement
+  private readonly modelsToggle: HTMLButtonElement
+  private readonly presetsToggle: HTMLButtonElement
+  private readonly modelsCurrent: HTMLElement
+  private readonly presetsCurrent: HTMLElement
   private readonly effortControl: HTMLElement
   private readonly effortValue: HTMLElement
   private readonly effortSlider: HTMLInputElement
@@ -58,6 +62,10 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
     this.source = requiredElement(document, 'configuration-source')
     this.models = requiredElement(document, 'configuration-models')
     this.presets = requiredElement(document, 'configuration-presets')
+    this.modelsToggle = requiredElement(document, 'configuration-models-toggle')
+    this.presetsToggle = requiredElement(document, 'configuration-presets-toggle')
+    this.modelsCurrent = requiredElement(document, 'configuration-models-current')
+    this.presetsCurrent = requiredElement(document, 'configuration-presets-current')
     this.effortControl = requiredElement(document, 'effort-control')
     this.effortValue = requiredElement(document, 'effort-value')
     this.effortSlider = requiredElement(document, 'effort-slider')
@@ -94,6 +102,9 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
     this.panel.classList.remove('hidden')
     this.toggle.classList.add('active')
     this.toggle.setAttribute('aria-expanded', 'true')
+    // A targeted open (e.g. /model, /preset) must reveal its collapsed group.
+    if (section === 'model') this.expandGroup(this.modelsToggle)
+    if (section === 'preset') this.expandGroup(this.presetsToggle)
     const target = section === 'reasoning'
       ? this.effortSlider
       : section === 'preset'
@@ -108,12 +119,28 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
     this.toggle.setAttribute('aria-expanded', 'false')
   }
 
+  /** Folder-style collapse for the Models / DSH Modes groups. */
+  private toggleGroup(toggle: HTMLButtonElement): void {
+    const group = toggle.closest('.configuration-group')
+    if (group === null) return
+    const collapsed = group.classList.toggle('collapsed')
+    toggle.setAttribute('aria-expanded', String(!collapsed))
+  }
+
+  private expandGroup(toggle: HTMLButtonElement): void {
+    toggle.closest('.configuration-group')?.classList.remove('collapsed')
+    toggle.setAttribute('aria-expanded', 'true')
+  }
+
   private bindEvents(): void {
     this.toggle.addEventListener('click', () => {
       if (this.panel.classList.contains('hidden')) this.open()
       else this.close()
     })
     this.closeButton.addEventListener('click', () => this.close())
+    for (const toggle of [this.modelsToggle, this.presetsToggle]) {
+      toggle.addEventListener('click', () => this.toggleGroup(toggle))
+    }
     this.source.addEventListener('change', () => {
       this.render(this.store.selectSource(this.source.value))
       this.options.onChange()
@@ -183,6 +210,7 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
   }
 
   private renderModels(snapshot: ComposerConfigurationSnapshot): void {
+    this.modelsCurrent.textContent = snapshot.model.label
     const fragment = this.options.document.createDocumentFragment()
     const groups = new Map<string, ModelConfigurationOption[]>()
     for (const model of snapshot.input.models) {
@@ -209,6 +237,7 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
   }
 
   private renderPresets(snapshot: ComposerConfigurationSnapshot): void {
+    this.presetsCurrent.textContent = snapshot.preset.label
     const fragment = this.options.document.createDocumentFragment()
     for (const preset of snapshot.input.presets) {
       const active = preset.id === snapshot.selection.agentPreset


### PR DESCRIPTION
## Summary
- render the Models and DSH Modes groups collapsed by default, with the current selection summarised in the group header
- keep the effort control visible without scrolling; targeted opens (/model, /preset) still expand their group

Stacked on the webview-modules refactor.

## Test plan
- `npm run check-types`
- `npm test` (112 passed)