### PR TITLE
fix: smooth out the effort slider drag

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -676,9 +676,17 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .configuration-option-copy small.configuration-option-provider { color: #9b7cff; font-weight: 600; }
 .configuration-option.active .configuration-option-copy small { color: inherit; opacity: .78; }
 .configuration-option-check { text-align: center; font-size: 13px; }
+/* Registering --effort-progress lets Chromium interpolate the slider fill
+   between detents instead of jumping. */
+@property --effort-progress {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
 .effort-control {
   --effort-color: #9b7cff;
   --effort-progress: 50%;
+  --effort-position: .5;
   padding: 9px 11px 8px;
   display: grid;
   gap: 4px;
@@ -698,18 +706,27 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .effort-heading strong::before { content: '('; }
 .effort-heading strong::after { content: ')'; }
 .effort-slider-row { width: min(160px, 54%); height: 50px; position: relative; flex: none; }
-#effort-slider { position: absolute; top: 0; left: 0; z-index: 2; width: 100%; height: 31px; margin: 0; padding: 0 7px; appearance: none; -webkit-appearance: none; background: color-mix(in srgb, var(--effort-color) 24%, var(--vscode-editorWidget-background)); border: 1px solid color-mix(in srgb, var(--effort-color) 34%, var(--vscode-widget-border)); border-radius: 999px; cursor: ew-resize; }
+#effort-slider { position: absolute; top: 0; left: 0; z-index: 2; width: 100%; height: 31px; margin: 0; padding: 0 7px; appearance: none; -webkit-appearance: none; background: linear-gradient(to right, color-mix(in srgb, var(--effort-color) 74%, var(--vscode-editorWidget-background)) 0 var(--effort-progress), color-mix(in srgb, var(--effort-color) 13%, var(--vscode-editorWidget-background)) var(--effort-progress) 100%); border: 1px solid color-mix(in srgb, var(--effort-color) 34%, var(--vscode-widget-border)); border-radius: 999px; cursor: grab; transition: --effort-progress 240ms cubic-bezier(.3, .9, .3, 1), background-color 160ms ease, border-color 160ms ease; }
+#effort-slider:active { cursor: grabbing; }
+#effort-slider:disabled { cursor: default; }
+/* The native thumb stays as an invisible hit target; the visible knob is the
+   .effort-thumb overlay so it can glide between detents via a CSS transition. */
 #effort-slider::-webkit-slider-runnable-track { height: 4px; background: transparent; border-radius: 999px; }
-#effort-slider::-webkit-slider-thumb { width: 23px; height: 23px; margin-top: -10px; appearance: none; -webkit-appearance: none; background: #fff; border: 3px solid color-mix(in srgb, var(--effort-color) 88%, #fff); border-radius: 50%; box-shadow: 0 1px 5px color-mix(in srgb, #000 42%, transparent); transition: border-color 160ms ease, transform 120ms ease; }
-#effort-slider::-webkit-slider-thumb:hover { transform: scale(1.08); }
+#effort-slider::-webkit-slider-thumb { width: 23px; height: 23px; margin-top: -10px; appearance: none; -webkit-appearance: none; opacity: 0; cursor: grab; }
+#effort-slider:active::-webkit-slider-thumb { cursor: grabbing; }
 #effort-slider::-moz-range-track { height: 4px; background: transparent; border-radius: 999px; }
 #effort-slider::-moz-range-progress { height: 4px; background: transparent; border-radius: 999px; }
-#effort-slider::-moz-range-thumb { width: 19px; height: 19px; background: #fff; border: 3px solid var(--effort-color); border-radius: 50%; box-shadow: 0 1px 5px color-mix(in srgb, #000 42%, transparent); }
+#effort-slider::-moz-range-thumb { width: 23px; height: 23px; opacity: 0; background: transparent; border: 0; cursor: grab; }
+.effort-thumb { position: absolute; top: 4px; left: calc(7px + (100% - 37px) * var(--effort-position)); z-index: 4; box-sizing: border-box; width: 23px; height: 23px; pointer-events: none; background: #fff; border: 3px solid color-mix(in srgb, var(--effort-color) 88%, #fff); border-radius: 50%; box-shadow: 0 1px 5px color-mix(in srgb, #000 42%, transparent); transition: left 240ms cubic-bezier(.3, .9, .3, 1), border-color 160ms ease, transform 120ms ease; }
+.effort-slider-row:hover .effort-thumb { transform: scale(1.08); }
+.effort-slider-row:active .effort-thumb { transform: scale(1.14); }
 .effort-ticks { position: absolute; top: 0; left: 11px; right: 11px; z-index: 3; height: 50px; pointer-events: none; }
 .effort-tick { position: absolute; left: var(--effort-stop); bottom: 0; min-width: 34px; height: 18px; padding: 0 3px; transform: translateX(-50%); pointer-events: auto; color: var(--vscode-descriptionForeground); background: transparent; border: 0; border-radius: 6px; font-size: 10px; line-height: 18px; }
 .effort-tick::before { content: ''; position: absolute; top: -19px; left: 50%; width: 6px; height: 6px; transform: translateX(-50%); background: color-mix(in srgb, var(--vscode-descriptionForeground) 48%, transparent); border-radius: 50%; }
 .effort-tick.active { color: var(--effort-color); }
-.effort-tick.active::before { background: var(--effort-color); }
+/* Passed dots ride on the filled portion of the track, so they flip to white
+   to stay visible against the effort colour. */
+.effort-tick.active::before { background: color-mix(in srgb, #fff 92%, transparent); }
 .effort-tick[aria-current='true'] { color: var(--vscode-foreground); font-weight: 600; }
 .effort-tick[aria-current='true']::before { opacity: 0; }
 .effort-control p { margin: 0; color: var(--vscode-descriptionForeground); font-size: 10px; line-height: 1.35; }

--- a/src/ui/workbench-view-provider.ts
+++ b/src/ui/workbench-view-provider.ts
@@ -564,6 +564,7 @@ export class WorkbenchViewProvider implements vscode.WebviewViewProvider, vscode
               <div class="effort-slider-row">
                 <input id="effort-slider" type="range" min="0" max="2" step="1" value="1" aria-label="${text('configurationEffort')}">
                 <div id="effort-ticks" class="effort-ticks"></div>
+                <span class="effort-thumb" aria-hidden="true"></span>
               </div>
             </div>
             <p id="configuration-hint">${text('configurationAppliesNextMessage')}</p>

--- a/src/webview/composer-configuration/component.ts
+++ b/src/webview/composer-configuration/component.ts
@@ -260,10 +260,11 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
     this.effortSlider.value = String(snapshot.effortIndex)
     this.effortSlider.disabled = snapshot.reasoning.length <= 1 || !snapshot.input.editable
     this.effortSlider.setAttribute('aria-valuetext', snapshot.effort.label)
-    const progress = snapshot.reasoning.length <= 1
+    const fraction = snapshot.reasoning.length <= 1
       ? 0
-      : snapshot.effortIndex / (snapshot.reasoning.length - 1) * 100
-    this.effortControl.style.setProperty('--effort-progress', `${progress}%`)
+      : snapshot.effortIndex / (snapshot.reasoning.length - 1)
+    this.effortControl.style.setProperty('--effort-progress', `${fraction * 100}%`)
+    this.effortControl.style.setProperty('--effort-position', String(fraction))
     const fragment = this.options.document.createDocumentFragment()
     snapshot.reasoning.forEach((effort, index) => {
       const button = this.options.document.createElement('button')


### PR DESCRIPTION
## Summary
- keep a `grab`/`grabbing` cursor on the track and thumb for the whole drag instead of falling back to the default cursor over the native thumb
- fill the track up to the active detent and interpolate the fill through a registered `--effort-progress` custom property
- render the knob as an `.effort-thumb` overlay positioned by `--effort-position` so it glides between detents; the native thumb stays as an invisible hit target

Stacked on the collapsible-groups change.

## Test plan
- `npm run check-types`
- `npm test` (112 passed)
- manual: drag the effort slider in the chat composer; cursor stays a hand, knob and fill glide between detents