### PR TITLE
feat: pop a judgement flourish when the effort tier changes

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -687,6 +687,7 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
   --effort-color: #9b7cff;
   --effort-progress: 50%;
   --effort-position: .5;
+  position: relative;
   padding: 9px 11px 8px;
   display: grid;
   gap: 4px;
@@ -730,6 +731,54 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .effort-tick[aria-current='true'] { color: var(--vscode-foreground); font-weight: 600; }
 .effort-tick[aria-current='true']::before { opacity: 0; }
 .effort-control p { margin: 0; color: var(--vscode-descriptionForeground); font-size: 10px; line-height: 1.35; }
+/* Rhythm-game judgement popup fired when the effort tier changes, styled
+   after the dsh-bgm hit effects: italic judgement word, glow, burst ring. */
+.effort-flourish {
+  position: absolute;
+  top: -15px;
+  right: 12px;
+  z-index: 6;
+  pointer-events: none;
+  font-size: 16px;
+  font-weight: 800;
+  font-style: italic;
+  letter-spacing: .1em;
+  animation: effort-flourish-pop 760ms cubic-bezier(.18, .89, .32, 1.1) forwards;
+}
+.effort-flourish::before {
+  content: '';
+  position: absolute;
+  inset: -7px -12px;
+  z-index: -1;
+  border: 2px solid var(--flourish-color);
+  border-radius: 50%;
+  opacity: 0;
+  animation: effort-flourish-ring 560ms ease-out;
+}
+.effort-flourish-off { --flourish-color: #8b8b93; color: var(--flourish-color); }
+.effort-flourish-low { --flourish-color: #3f9be0; color: #5db2f0; text-shadow: 0 0 10px color-mix(in srgb, var(--flourish-color) 60%, transparent); }
+.effort-flourish-high { --flourish-color: #9b7cff; color: #b89aff; text-shadow: 0 0 12px color-mix(in srgb, var(--flourish-color) 65%, transparent); }
+.effort-flourish-max {
+  --flourish-color: #ffb347;
+  background: linear-gradient(180deg, #ffe27a 8%, #ffb347 55%, #ff7a3c);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--flourish-color) 70%, transparent));
+}
+@keyframes effort-flourish-pop {
+  0% { opacity: 0; transform: translateY(8px) scale(1.65); }
+  22% { opacity: 1; transform: translateY(0) scale(1); }
+  68% { opacity: 1; transform: translateY(-5px) scale(1); }
+  100% { opacity: 0; transform: translateY(-12px) scale(.92); }
+}
+@keyframes effort-flourish-ring {
+  0% { opacity: .9; transform: scale(.35); }
+  100% { opacity: 0; transform: scale(1.35); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .effort-flourish, .effort-flourish::before { animation-duration: 1ms; }
+}
 .editor-context-list {
   max-height: 112px;
   padding: 9px 10px 0;

--- a/src/webview/composer-configuration/component.ts
+++ b/src/webview/composer-configuration/component.ts
@@ -6,6 +6,7 @@ import type {
   ComposerConfigurationSnapshot,
   ConfigurationOption,
   ConfigurationSection,
+  EffortTone,
   ModelConfigurationOption,
 } from './types.js'
 
@@ -146,14 +147,12 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
       this.options.onChange()
     })
     this.effortSlider.addEventListener('input', () => {
-      this.render(this.store.selectReasoning(Number(this.effortSlider.value)))
-      this.options.onChange()
+      this.changeReasoning(Number(this.effortSlider.value))
     })
     this.effortSlider.addEventListener('wheel', (event) => {
       event.preventDefault()
       const direction = event.deltaY > 0 ? 1 : -1
-      this.render(this.store.selectReasoning(Number(this.effortSlider.value) + direction))
-      this.options.onChange()
+      this.changeReasoning(Number(this.effortSlider.value) + direction)
     }, { passive: false })
     this.options.document.addEventListener('pointerdown', (event) => {
       const target = event.target
@@ -167,6 +166,27 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
         this.toggle.focus()
       }
     })
+  }
+
+  /** Applies a user-driven reasoning change and pops the tier flourish. */
+  private changeReasoning(index: number): void {
+    const before = this.store.snapshot()?.effortTone
+    const snapshot = this.store.selectReasoning(index)
+    this.render(snapshot)
+    if (snapshot !== undefined && snapshot.effortTone !== before) this.flourish(snapshot.effortTone)
+    this.options.onChange()
+  }
+
+  /** Rhythm-game style judgement popup shown when the effort tier changes. */
+  private flourish(tone: EffortTone): void {
+    const burst = this.options.document.createElement('span')
+    burst.className = `effort-flourish effort-flourish-${tone}`
+    burst.setAttribute('aria-hidden', 'true')
+    burst.textContent = FLOURISH_LABEL[tone]
+    burst.addEventListener('animationend', () => burst.remove())
+    this.effortControl.append(burst)
+    // animationend does not fire when animations are disabled; sweep anyway.
+    setTimeout(() => burst.remove(), 1200)
   }
 
   private render(snapshot: ComposerConfigurationSnapshot | undefined): void {
@@ -277,8 +297,7 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
       const position = snapshot.reasoning.length <= 1 ? 50 : index / (snapshot.reasoning.length - 1) * 100
       button.style.setProperty('--effort-stop', `${position}%`)
       button.addEventListener('click', () => {
-        this.render(this.store.selectReasoning(index))
-        this.options.onChange()
+        this.changeReasoning(index)
       })
       fragment.append(button)
     })
@@ -317,6 +336,13 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
     button.append(iconElement, copy, check)
     return button
   }
+}
+
+const FLOURISH_LABEL: Record<EffortTone, string> = {
+  off: 'MISS',
+  low: 'GOOD',
+  high: 'GREAT',
+  max: 'PERFECT',
 }
 
 function requiredElement<T extends HTMLElement>(document: Document, id: string): T {


### PR DESCRIPTION
## Summary
- switching the reasoning effort now bursts a rhythm-game style judgement above the slider, in the spirit of the dsh-bgm hit effects: MISS (off), GOOD (low), GREAT (high) and a gold gradient PERFECT with a burst ring when reasoning is maxed out
- fires on slider drags, tick clicks and wheel steps whenever the tone actually changes; respects prefers-reduced-motion

Stacked on the slider drag fix.

## Test plan
- `npm run check-types`
- `npm test` (112 passed)
- manual: move the effort slider across tiers and watch the judgement pop; max tier shows the gold PERFECT burst