### PR TITLE
fix: clip long model names in the composer toggle and tint its icon by effort

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -991,12 +991,20 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .context-meter-ring { width: 18px; height: 18px; position: relative; display: block; background: conic-gradient(var(--context-color) var(--context-progress), color-mix(in srgb, var(--vscode-descriptionForeground) 24%, transparent) 0); border-radius: 50%; transition: background 180ms ease; }
 .context-meter-ring::after { content: ''; position: absolute; inset: 3px; background: var(--vscode-input-background); border-radius: 50%; }
 .context-meter-value { min-width: 22px; white-space: nowrap; }
-.configuration-toggle { width: auto; min-width: 0; max-width: 150px; height: 32px; padding: 4px 7px; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 5px; align-items: center; color: var(--vscode-foreground); background: color-mix(in srgb, var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background)) 70%, transparent); border: 1px solid var(--vscode-widget-border); border-radius: 10px; }
+.configuration-toggle { width: auto; min-width: 0; max-width: 150px; height: 32px; padding: 4px 7px; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 5px; align-items: center; overflow: hidden; color: var(--vscode-foreground); background: color-mix(in srgb, var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background)) 70%, transparent); border: 1px solid var(--vscode-widget-border); border-radius: 10px; }
 .configuration-toggle:hover, .configuration-toggle.active { background: var(--vscode-toolbar-hoverBackground); border-color: var(--vscode-focusBorder); }
-.configuration-toggle.pending { box-shadow: inset 0 0 0 1px color-mix(in srgb, #9b7cff 65%, transparent); }
-.configuration-toggle-icon { color: #9b7cff; font-size: 14px; }
+.configuration-toggle.pending { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--toggle-effort, #9b7cff) 65%, transparent); }
+/* The icon tint follows the active reasoning tier, mirroring the effort
+   control palette (off / low / high / max). */
+.configuration-toggle-icon { color: var(--toggle-effort, #9b7cff); font-size: 14px; transition: color 160ms ease; }
+.configuration-toggle[data-effort='off'] { --toggle-effort: #8b8b93; }
+.configuration-toggle[data-effort='low'] { --toggle-effort: #3f9be0; }
+.configuration-toggle[data-effort='high'] { --toggle-effort: #9b7cff; }
+.configuration-toggle[data-effort='max'] { --toggle-effort: #e8784f; }
 .configuration-toggle-copy { min-width: 0; display: block; line-height: 1.2; text-align: left; }
-.configuration-toggle-copy strong, .configuration-toggle-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* strong/small are inline by default, where overflow + ellipsis never apply;
+   block boxes are what actually clip long model names inside the pill. */
+.configuration-toggle-copy strong, .configuration-toggle-copy small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .configuration-toggle-copy strong { font-size: 11px; }
 .configuration-toggle-copy small { display: none; color: var(--vscode-descriptionForeground); font-size: 10px; }
 .configuration-toggle-chevron { color: var(--vscode-descriptionForeground); font-size: 9px; transition: transform 140ms ease; }

--- a/src/webview/composer-configuration/component.ts
+++ b/src/webview/composer-configuration/component.ts
@@ -235,6 +235,7 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
   private render(snapshot: ComposerConfigurationSnapshot | undefined): void {
     if (snapshot === undefined) {
       this.toggle.disabled = true
+      delete this.toggle.dataset.effort
       this.close()
       return
     }
@@ -249,6 +250,8 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
       effort: snapshot.effort.label,
     })
     this.toggle.classList.toggle('pending', snapshot.dirty)
+    // Tints the toggle icon (and pending ring) with the active effort tone.
+    this.toggle.dataset.effort = snapshot.effortTone
     this.renderSources(snapshot)
     this.renderModels(snapshot)
     this.renderPresets(snapshot)


### PR DESCRIPTION
## Summary
- the `strong`/`small` inside the toggle copy were inline elements, where `overflow`/`text-overflow: ellipsis` never apply, so long model ids painted past the pill border in the bottom-right composer; they are block boxes now, with `overflow: hidden` on the pill as a safety net
- the toggle icon (and the pending ring) now follow the active reasoning tier colour, mirroring the effort control palette (off → gray, low → blue, high → purple, max → orange)

## Test plan
- `npm run check-types`
- `npm test` (113 passed)
- manual: pick a relay model with a long id — the name ellipsises inside the pill; switch reasoning tiers — the ◈ icon follows the tier colour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the configuration toggle’s visual states, including pending status and effort-level color indicators.
  * Added smoother icon color transitions and improved label truncation for narrow layouts.
* **Bug Fixes**
  * Corrected effort-tone display when configuration details are unavailable or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->