### PR TITLE
chore: bump the bundled dsh runtime to 0.1.1-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A native VS Code coding-agent extension powered by [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). Install the platform-specific VSIX and start working—there is no upstream repository to clone, no Node/npm setup, and no local Harness deployment to manage.
 
-> This is a community-maintained `0.4.8` release. DeepSeek Harness is currently a Developer Preview, and this extension pins the official `@deepseek-ai/dsh@0.1.0-rc.7` package.
+> This is a community-maintained `0.4.8` release. DeepSeek Harness is currently a Developer Preview, and this extension pins the official `@deepseek-ai/dsh@0.1.1-rc.1` package.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 在 VS Code 中原生运行 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的 AI 编码助手扩展。无需克隆上游仓库、安装 Node/npm 或手动部署 Harness；安装匹配平台的 VSIX 即可使用。
 
-> 当前为社区开发版本 `0.4.8`。DeepSeek Harness 仍处于 Developer Preview，本扩展固定使用官方 npm 包 `@deepseek-ai/dsh@0.1.0-rc.7`。
+> 当前为社区开发版本 `0.4.8`。DeepSeek Harness 仍处于 Developer Preview，本扩展固定使用官方 npm 包 `@deepseek-ai/dsh@0.1.1-rc.1`。
 
 ## 功能
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 This platform extension bundle contains:
 
-- `@deepseek-ai/dsh` 0.1.0-rc.7 and its `@deepseek-ai/dsh-*` dependencies
+- `@deepseek-ai/dsh` 0.1.1-rc.1 and its `@deepseek-ai/dsh-*` dependencies
   - Copyright: DeepSeek contributors
   - License: MIT
   - Source: https://github.com/deepseek-ai/deepseek-harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "deepseek-harness-for-vscode",
-  "version": "0.4.8-dev",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-for-vscode",
-      "version": "0.4.8-dev",
+      "version": "0.4.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh": "0.1.0-rc.7",
+        "@deepseek-ai/dsh": "^0.1.1-rc.1",
         "dompurify": "3.4.13",
         "markdown-it": "15.0.0",
         "node": "22.22.3",
@@ -181,12 +181,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
-      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
+        "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
@@ -393,12 +393,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
-      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
+        "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
@@ -818,9 +818,9 @@
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh/-/dsh-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ZceDCJ8FAywih+USW/OMk9jEhunlvJBGEz4kqrhau23hPzbciOazZrywH0nBRsaalSeAJ1JGBmjtw4OSjToStw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh/-/dsh-0.1.1-rc.1.tgz",
+      "integrity": "sha512-HVauMT0F7MWUctkxzBcu5PMFc8j0lm0kX+4IbcUsA7Oh+/xv7xhigEDP0SaSOM/kR48U/BldHbZru116DcZz0w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
@@ -828,59 +828,60 @@
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-base": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-headless": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-persona": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-schedule": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-reference": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-time-context": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web-app": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -890,80 +891,80 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AqBQavJYgbCUUYBHP7OGCaw8WN5082NXYQOoOfNRO72bub3E+/nWkl8b4B7BAJdFfyLo9ce+Kgb1BCHSJU/JLg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xE+oni6Ig32Q7QspcUVQqGOa9QYiWwwaqG8ci43+oc2vfslXbD9RJ+qnk9XFKidnVn6cwB95Aw4eeivy0ufDCg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.7.tgz",
-      "integrity": "sha512-zHtD4FAqxzidyNiyx1bpvLHdOTTsKnmjlHRqDS1KegIMSTNFmmp1B2bHdAUXp/OH7fPDmv+1ZXzDoJhBNUY9jA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PZl4y+vW3nhaYljebQ0mZELKvfw61neybWeuMYBdprrM0TnjbYStY0drxynowxqaGoBPUO5Ty3q9Px4hbUYaLw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.0-rc.7.tgz",
-      "integrity": "sha512-laLz5ee7tKqVzrj15ztHuOnJLxDiGlqFOm6mEJUjJPWWD9Yzj1Iq+6WHZZ3Hw66vrNzYKqEN0TBofWF3DA7OzQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-/BZNgV2qnwERp4EpH0Lu/U6RWUDEu+u7W0Xu9y3/b0PvGsBz5oeucPnaFOKEXIIHDVnuFvo2513sYOsaoj0xWA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.0-rc.7.tgz",
-      "integrity": "sha512-98jV+6XnkZ93g4C1BJ/hCcC8k4GVhH+oNrkhLFvc6aOQz6o+9kdV8IrgEVr0qRcAfHKlCMfiV4BIDz4eBBoziw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Cu/z/oT5DPV6jDU9+X1Hbi0ex4OPHMF7eK9+sMOjvgJSlXJWU2Htg7/XfFEOLMkrerA48CopieWrbNLSL1pFGg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.7.tgz",
-      "integrity": "sha512-T/VcMV7lrXCFmRKrtoMTAz5DAdUmku6hz95wbikRvRc0WizIwQ3R04ke9KIeDiQcxK8xkE8cx+IYqEWa9C5gPg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-m+IitPjH4knw1fWzIv/6AqkLj6vRH956oop0okNAa5tkbyz9B4XwR7I81+2ifqc7btp2e5TIBl8lgx4WyxUbhg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -973,89 +974,91 @@
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.0-rc.7.tgz",
-      "integrity": "sha512-RAtrfRyLZ/ob9lW5/fKeU7T4LYPTXYP7qCmu2i7ZBqwHseMdYHk0U1Ti8z2kr2NF4LIzHNUXIwaE9s7za5cwuA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XH7Fik0+ktVGzx4FEvFKDDYJNYU/AhQfcyPi/BNhIegBPCXAdLTbomwh3bb5FBhMiYcwq1bPQknxS8kN+tmuFA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.0-rc.7.tgz",
-      "integrity": "sha512-g39W2HSWum6ghJG3src3rLVR8mnCsc0xCBSRpef1Fxgsjjn1LS2KNstKThXQtn7lYQZM/DNE7uiaOmsLxayeJQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SBXf0wg4HO9PDTb+GFJuSQ8OzARDojF0UhoveD/j1roF6X6pnRjkDsRaYUWg3Uwmim3Bc5Dckutgu9p14hFn1Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.7.tgz",
-      "integrity": "sha512-tcoOuHMSqYqCtMxLjWBHKN+glS56XaUo3ImphvDvUkB84FyU3btHNJbYeAt2oXoWbHfOedcIRWpfNN4tSmhPwQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+fi1Zo1bY1dB+Qr5Q+iLxr1kSL9sigWhdMiK0tV9dAPY4BxOunwjiTh614P6jsRTvDAh/VDaHEQsHcv1T4YY9Q==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.7.tgz",
-      "integrity": "sha512-dsP69u0avHRcJTPzngudqCm73UaTxNvGi/557DNPi3cOSoIh1SyPzPgk8W8rQQEFTL07rkwt8KfdQoMU5ga1fg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TOeb0DsrjUyZIlL/Ih1loEg2UelVQdLX9Vck6LgCjZcH7UJvQdYuMKt5G8Tbvms3ZHvlpvCc7kue4sQlZ9rKDA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.0-rc.7.tgz",
-      "integrity": "sha512-3qgv994YzNGrlDcOyarL4vqNky3ttmYsUhDsMgGdefALK6gpL7ZCWF+9m0ehZjGY0Rb4VcBdieJYOY2EgpWb0w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.1.tgz",
+      "integrity": "sha512-gef6HqCpdf/aLXH8G4TZ+fIxtq+ebiKDrtr2pslFiopWWrxEvqhZdNPgpiC9A8IDfX3waOxcNxhvmlPHpV2moQ==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"
@@ -1066,10 +1069,10 @@
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-hmr": {
@@ -1078,31 +1081,31 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.7.tgz",
-      "integrity": "sha512-LxRx6K8FJ8bXZHiNhH6Rvj+jh/ZIpolmsmi138XrvMUGvbOBWE6QLbdzcgTgwrYZm5GP2kqqLe/3gQlgtt2bXA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.1.tgz",
+      "integrity": "sha512-8cSMtRK2+5OcyvRhyJRI6lVVuIp+r7MBKGlfESOIdK50OWnVUM35IvaWXuwQrMOI/xJDihyDF+KGF1o0aM1vhg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.7.tgz",
-      "integrity": "sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-R5xKO2z+91Ze25E+ghk3qDJf7ZA4t2sqMF1wusp2/6KrF0UzhCpGt/SWtdjRXSwz6DTjsAfZzpPC5D+2EmuHxA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-7i2Fuj811MFeqrUYnpEG3VBoShZEjQ7zNXdLOa1W5hZ4TWV+tUjX7pJoN88U1LOgEOWMc9uzSPqGA5/aKBYgdQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KGJVu0q3yPlcfoPg+4FGTI1O8sS08B/POQ4jLQvKG7sjx3kXXx/S8xD5BTeFuYijM3mSCCC96AI4lha28v+04Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1110,104 +1113,117 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-authorization": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cf8LRUJJgpr88UVOPViQviKO+LJ92kdh465c4BvbO1HJDBHXME6fAgkDpDs+IbKdrdt3KWYqI/x2UK7tnFWqXg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-base/-/dsh-base-0.1.0-rc.7.tgz",
-      "integrity": "sha512-lpAMUO3PdxZwLnCQOdOZ/fu7eI27Ckz3Ec9MB9QYL4u34yatndCliTrGaFBDoNHoWt3V4gojzszRFrEx+Vce/g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fJ4IlNFjAHj+5PTByTAs6fEj7GFirNmpL0eYA+KTwK5SGEupJ0COVCBOsDeNMUJZspsDKptkZm0szo2u09Q0MQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings-file": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-spill-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-web": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-fsw2Ex5ExyX4A62P1+fodbnUG4PXOSyHAM4YtaLg2kcPcElLwatYNPG3gEuulxwbpWDlx/OWvbjHThnJUuzaoA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-e0hgZMtQYPGSjB2gCJ6nTMlfKF+NXCE9IN6Z3TrpWMF9CQmqqqbyrUcY3+/JTVsoNoUk1aAMxMbXNFtGcYqEng==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1215,62 +1231,62 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.0-rc.7.tgz",
-      "integrity": "sha512-xX+XhqPeRaOqMPDNk8dPboHza2pP13hTIMt+ztvd8WpD0t35idrNrcsXEYs+CtKiFWn6I05WB1BeAimWkLDOcg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-kH/rW2aXxlFoKpF+eLJcfO/WYvQxmqJYmmHzEZbJgbzbs6V6t1O2PMHnjIRvZXgzP4jXeb3a4+YwJzjfxVX13Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.7.tgz",
-      "integrity": "sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.1.tgz",
+      "integrity": "sha512-u5+q1x5koviWTTaOiOUA0629ZNEKaRl2hu7iiGArzhvj+CUz7abh2b6IF3+xI4AMSHyvn+mOWN9Vwa2WVfwGLg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.7.tgz",
-      "integrity": "sha512-JZWDKCbwKHOUcm7+JadKA3aJCSEB34XfPycCtPgdWfABIiHMaSpnmSVy/8Jed4hw6hxhnR6A3rnvW02Xr2yqwA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-43j158P+X9hjJMZ76NsJsQTTDo7ws+aW5XMq3PmdJRVY6h15JsPrfALNosjaeiJjqxUXKSNOfHk7Oq8vJejsyw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "ws": "^8.21.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.0-rc.7.tgz",
-      "integrity": "sha512-uJVHLMgmf19JI7UCqrC8jipf/5oaM539RPJ5sNv+BJCbt9Ik6VqaKbu4uiF+gz8i8EqbXV3D9criL1IiCS+pdg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VQVrUtiBLB1FIvjlVBHx3OmK/TpR/nMoDqgxXFV9d0AAs3LdL20r9pSDcngpO0dhDI26LI9dcsgmVIp0MmV5AQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -1278,648 +1294,565 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.0-rc.7.tgz",
-      "integrity": "sha512-1onX79wXJfAzdwIJPUI9jEVYeVQJfWwyQvyL/OmGrnkCs8srJHIXBdYtsUC7ILlR13y5nOY4j6bifBOAoGRn6w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.1.tgz",
+      "integrity": "sha512-siclYHjadMhc+Wh0wmV5twiu9oyBE719POQ1F2nM+H0mfScokHLqpBHkml8AJqIl0rkq3dxtkC19kUoBEJvNTQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.0-rc.7.tgz",
-      "integrity": "sha512-hczFl0TRH5sLt/dS0+TMCtQvfDoeLw/r88L6n3rXfY6Q1e4Yddg6RAv4kGsUoMoLYgWi7qPwD6HcUGgyKkDPHg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cdBFlFE8sb+vD/w3gYKTu8LH+yH4OyPHXhxJTkzhQJF3bAhdC24k25mogaxkpZXg4rcHS16zWyCriZaOGQRgsQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Ish2uFML2FibTpzo7QyVSt29jf/iG4j9BFQ41ychVMPRR3trJGM3h8CMuam3oKWlvB8OXVXFd6gO929w6PI0Ew==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.1.tgz",
+      "integrity": "sha512-re0dq+vXlGIGMs5qQHJLMHael8FN+9zKTnGk2M0BQUH4fGr3jTOBUvoKUztbjW/DJP3l3f1k6uoDj2ri3DA0nA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
         "immer": "^10.1.1",
-        "react": "^18.2.0",
         "zustand": "~4.4.7"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-client-schema-form": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-schema-form/-/dsh-client-schema-form-0.1.0-rc.7.tgz",
-      "integrity": "sha512-acGeXjGl2lMqCO+jY1z9/FKbIiskk7FZO266OSBOwHJQP6yBd5MBnrvtPJUB3glP6xsQK8neFLLtRwVgRJ+GqQ==",
+    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.1.tgz",
+      "integrity": "sha512-z7u+1fFUURCQrpBXdqtcolPYpW1w6myFZBGMMgZeDpHP94p1CUsJ1KM/AP1FXJqnG4QmtbXaVQx6jR0LjAYdYA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-mOZQO7jozY/kX7m8jHm6h9VbXYMKPVAyhtJI0wPJXzL/DoqCvyN/SBaQ88Me+OM4bgn/Io3yj54r2wAoxdp7eA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.1.tgz",
+      "integrity": "sha512-CuWaMd44IEpF9878yZdI13Vd/Ky8hlEag4KXWs5G3C01eAQTS2oM0FyIwohtNnIOPqo2LygHWKpSqKYfDYTvIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ht3Nd+kczdVK5/w50xp/qpTozwiHTCZW5/R9w7093DapF3mAYQ7Hd0q2NmonNAIchVixj5gbB4zktUbdIaMOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xHe2R37UevVNHV0/ieHPdFHuZWTlYIuEYBowLBcQ51Tz2XurWnjcM5CLFr/AChkIuw06dk/Ywm4nwjcCBKgCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.1.tgz",
+      "integrity": "sha512-U1T7BRdH5TaVg1W2YcBUAQleFEw9f47DFSAYEpyrcZRJX21p9/Zh+ZZErQAR9A8BbdiYOP0GdUJ28EPiEQfxtA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q3b8QGGLvf/zlztdFqmAonphDbt66GbDifOvTXp+U9Stc3cy2wAvImyFUMwxM1RWdI9tdozrJBu3q/u7UVrVsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.1.tgz",
+      "integrity": "sha512-g/LzjEqk9Ba+RMBCKYCAlyAadG9/9biEJQepTDmbVUrfjo6rVS9tkpuMYrwpHbV94r3wSCBYQ2BXYM/VubgC/A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PrudUDCCLHLKt+QGODE3udg7Ce57s5mChZa2F0g6Anp1TYpRmRWbR/ErkyeDMrvAGllg0PqeVFGzaJ5O535gGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hQZ27T1+nX5B6S1ookTFpnobAQY9XrsFE7V0XXOTzGbDM6JbMhndgA8XnuOoAjVl84c8AkyBTJ6QxInJkF3HJw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.1.tgz",
+      "integrity": "sha512-QvseCqtZXE+/5DGHEQFG0FFtXU/kBkCEMODZOwl4bJwRWGjM5xEpHfS4Uqkf8x0VXsIbjE6txCmcByRLknkmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-baib2zmrD76/WMyBfbEzLSZMRAxSBYwgjTw1chDCo/2dYywwM7udfyb5WNuzBa4/e66xX0PibqEmsHFAW4mTww==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cqZj1SRW7Z5I6imNt0BjVu+S2SztNi/EQ2vjl+OqyVV6jLxJKYIhYIFOZaZTHuUpMb6NkxIO8qfPDBqFWE9F5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-DcaHmqROaU52mKM1ZuswWMNfzSABl0BrGST464KIKEzqHw/KOshrSKyeWi/j43I0TT8PeaiV5P+5m89QwPsdUg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VLn/XtMePhKMs2ozaoIUbgwsoLMQxfVNt96FZJEOCzctnXzlhehf1nVbEDoKR488N6yWWwKEXZSO6ySAuijZgg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-yOiXg2btX/htZJ5Z6R4NffOvJAKFRI8v0HczblqgGaHeSwYjZW0vasZ4dfs3oAWJxzCZOfeLHGNXthZXmHnQMA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.1.tgz",
+      "integrity": "sha512-byrSXTZnICVE7mtD0g+l4blWhNAUKFcN2y8akQObhLeOjxWSw7nTLxkpsjEyrHe8M0p+ciX8lLCmUn1N7jNsVQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hvsaGrNJjMOfnRJ5Uawhh0Ujf8zC69cSWHV4i5F7S7aSNhejrWDZkMIiHLV5hvg9GgRbzbQjdcCij8nJz2KpNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vF4l1it4InbuppD7Nnm7Nc1nWteqowTYBsooBdiRfwjet1fPL6z/Wmd2eV7tUgPNZZcWpunkQLhIzR+4D+Ho+w==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ORGAHRQ6aTWVlUYYTqlAmV5CI6/E1OCoJsE7rbeufA0zGagUx/bAgK1l6I3bzSGOVDxJ6ZRhwOxJWg/3K0ZBig==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.0-rc.7.tgz",
-      "integrity": "sha512-85GLGfg3iEISMhHxn9ZePkB/mtXIJdWkpvSHCm9bZizK8KiyRfA/OjDpKfk5kvG16xKNV0KQo65HOf0JdwtyXQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.0-rc.7.tgz",
-      "integrity": "sha512-IRA778yZpOaoJEkODlfydd6yuASf7hF229s64IY5zaY+22K7D+X1cmDo8D13UylxQXFPAomTlHtQtQpCtghKXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "clsx": "^2.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.0-rc.7.tgz",
-      "integrity": "sha512-gLuzEmgVhEIjVeLlmIAdKX/SEEFavnVOD0mQPlHIMqFAX/80yzYfRD7CMxXc0amOj7uBcw7qsSa4WzFvaWso3w==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.0-rc.7.tgz",
-      "integrity": "sha512-CyjFjP+oRJQ4ydX8WVrKUeloQnAJRA/fN6RRY6NAHldFC9pd1l8YogmTcR1JuCIlqzMnLRyYlGODQBYz8WOjmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.0-rc.7.tgz",
-      "integrity": "sha512-8OwbFdMHRIE7L2PvoIGwSOkhUYsznr9u773K3s64DMxp4oLLl3ZzHc2hfaOfQTTmyE7ItpDJm8Von42LsJBKaw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.0-rc.7.tgz",
-      "integrity": "sha512-uVN7TXKrGQMACKToSTPxOIeDlebQgi2OMiKBaKrYcI7jBsCRief3CTLziZ6Kups2h2s72Eo6gu/0eueccwLYew==",
-      "license": "MIT",
-      "dependencies": {
-        "react": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.0-rc.7.tgz",
-      "integrity": "sha512-5lj27c68wWqroyIOXmFPGUDFQxICDYEcYAJSuV5ZbnHXyN2cBTTDTW4zJPwisY5GhKfiJXjhS0YZqLi54/Xn+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.0-rc.7.tgz",
-      "integrity": "sha512-SZ9NuuIDrBjHJsEcnqwhbiCZknjkyNd0ZBHDl453p2WHkfA8zwDMUJRdAMWd0sC95WH2Yu4rMzkAVYjZwCBjVw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.0-rc.7.tgz",
-      "integrity": "sha512-zZEAbaA6ZCMw2ZDGMWFm+nBXnBBRfI8StRtx33GoFcJHlMIP5mJfuSm2gcFHdO+3aeAmuTf5G++DdWwLRLZv9A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Sfn4YlS6dKm/ojGRyZL5oq34+GSeyirzGkmqhtoX7hpjHAhBVmugz2jku2ijYEjjFtD6YKYdWwvQxHdRaHFZ+w==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.0-rc.7.tgz",
-      "integrity": "sha512-q8WvaB1gxj4OBPCLC/luDLQ7TRY2iwuhOZKrwG1MbXhSmfd14RiyKHG1p/5HIxwTJZfqnxuN69NzdAZY6cjU8g==",
-      "license": "MIT",
-      "dependencies": {
-        "react": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.0-rc.7.tgz",
-      "integrity": "sha512-4z5xkH/O8GT6ve1IX15WTel236fJwSuRZusMKJ9qIxdslZZ1h+wMbtgX3tCqg7mTtMznRDspCpC1b1QSAt4nTg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.0-rc.7.tgz",
-      "integrity": "sha512-B8y2+tu1xorpHmwo8KWsLFZwa4P0uFCI32H1SwYyQjBjoTbSb+TOfPA3i6na988XMiF8NCcxynTFzHRv/77AJw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Gr5goo9dEGCR/CqpeJgO1mGO1ZqoX4tpuAMuZoq3wmLwaeK8qOMMhHGTxGOI9NbBD1snvbUzOJP/LUoNrS61YQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "clsx": "^2.1.1",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.0-rc.7.tgz",
-      "integrity": "sha512-OO/miNmPCJS/5GffqXeBnPvdx1HnHvi9AHb4Uoy9N+zucwo7ZQV40lQ+ODcAX9UaRW/6x3a8CxQ3G4q1t/ltKQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.0-rc.7.tgz",
-      "integrity": "sha512-b6qqGcq5MxulD+XBxcD3ZewgJ17OUegeSA0Ov0afC4hvgyhWhZP3b+odH92ax7Ckaat8/Yx2j4NPpu81e30qLA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-primitives": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-primitives/-/dsh-client-ui-primitives-0.1.0-rc.7.tgz",
-      "integrity": "sha512-x3cnIAeOdDMd7no8JwP65q7J9Fj4xQWAZPPJY4MzgfQAAOcHJb0T0d5Uo4FXMiCcTeU/73n7BssS5PE7jjgiDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/langs": "^4.3.1",
-        "@types/mdast": "^4.0.4",
-        "anser": "^2.3.5",
-        "clsx": "^2.0.0",
-        "katex": "^0.16.47",
-        "mdast-util-from-markdown": "^2.0.3",
-        "mdast-util-gfm": "^3.1.0",
-        "mdast-util-math": "^3.0.0",
-        "micromark-core-commonmark": "^2.0.3",
-        "micromark-extension-gfm": "^3.0.0",
-        "micromark-extension-math": "^3.1.0",
-        "micromark-factory-space": "^2.0.1",
-        "micromark-util-character": "^2.1.1",
-        "micromark-util-classify-character": "^2.0.1",
-        "micromark-util-sanitize-uri": "^2.0.1",
-        "micromark-util-symbol": "^2.0.1",
-        "micromark-util-types": "^2.0.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "shiki": "^4.3.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.0-rc.7.tgz",
-      "integrity": "sha512-I02BGKw3/yG25yf5omsMwmwJ2CnFyxTvbxqgRgSmTCUxATkLT87K8SxcemRZqXnFXQZhm6Il6bwVCpVfRfmNoA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.0-rc.7.tgz",
-      "integrity": "sha512-L5heQqyzZ/Kd+/hj8Ptd89OOss6FI8TjD3iwC47V3Xj/8ZgtnHwEA7vSqeoTe03uzRz8Zd8ec+bz/q47z8/I/Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xFRY1mS71lRJtQiBtI/EFE6R6JymgjO26Co3h6zPwlhMbiLvWlq0hL919j8YQsiHOUEHdlLxk2FnjJc2eyYBTg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.0-rc.7.tgz",
-      "integrity": "sha512-q73sXPomdUGpucj6pgKuO3WrGzqCoqyZhbqOZQL7EIdJcl9N3P+tNhsNj+ls1UOcOpb36Ou2NzUdIeyHSNVmKg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.1.tgz",
+      "integrity": "sha512-E9CXWfP9lrdaeYlZNhCSYcl+nIirG/cO+r5je6rOPmfdvupyvkdrR5w+Co0yDKjMjz9NsZ1qyxNa7MFxC3GJwg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Ei6q5/UdUC9SxrTcbn/XR1NCe4iZgovhmbKCKBKBHMCNxhE0umdUJL8M7uKZdlpItJQ2ggiK9L8RmztKDmv59A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ycCL9EBBOCEZVJQfG9DsK3CAZ84s0/9tByY3csQXsALwDImBY1mPPmI5xp3ITJF28HYu6GC9CjlsZ0Q4CM/dXg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.0-rc.7.tgz",
-      "integrity": "sha512-oOOgj9NTv1GE+QdKhBfkcWG2+WS9uJz5NYgIZzahbg6xCbu4a2vugcCKcyslQEKKOB35mGHH/orPcoj2N+DeHg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0Ato2FscNSwpO7MaZ8mI5QtHoUvrgavuhcnETVfOlSBbjuqACZyGxLjWBaJ3jc+6RvsZTidg4uYZaAhRG7N2ZA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.0-rc.7.tgz",
-      "integrity": "sha512-YduvLROf3gniqYggfRfkvNDMtqvWlREmwxVtxullWTXhrgXmcPya7GCKJeru8ZuyrF3FU1XqOR8KJT+OzLSv7w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.1.tgz",
+      "integrity": "sha512-5Osuq606H4ii76cBhlhZHk41uEhwGjtptg05GZcFGIfPAbS+8KeDp58kwFzgKUyGKRtiYb2ssG7YQagaeqO2Fg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.0-rc.7.tgz",
-      "integrity": "sha512-jxqQhu4RkNjEf2zTm/h9qJZ+q/mHdSBVC05XqfsdNP1VRni9k9L/LcR2TWHfyuvM61drtdi5s+/ZW9pbxaQPiQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-UXkfLRMLHvU29l/A39vdU628vCiRKce9Wa1R6fQK6PbryF1fHA4u2btxTQyX656YadkGfpoRNbKTrwuHwTT8jg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-slots": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-slots/-/dsh-client-ui-slots-0.1.0-rc.7.tgz",
-      "integrity": "sha512-5rPP/6IWZflhiegVHU56IOPGHtrhLgBV44mOFn2JNVwiwxxmKeIhEcnYD4M0eKkI+pRiJIO5WvkRYokIGgyFiA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-geEZbS5N68tYJIPSToWIFPj0EjRiJBzryLvv3VL+INqt6urYCEm2uY7arNLUFJhHpjOJVi45ZM8qlh0qw5Sk7Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jtqR76/WVoFeuNFfHEEU/0lmw6ywECVRdNjNbr8xF4AFW7LNDGfIBjOW+r+c3VYs20uXe+KieKCE+hTtUcqYtA==",
       "license": "MIT",
-      "dependencies": {
-        "react": "^18.2.0"
-      },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.0-rc.7.tgz",
-      "integrity": "sha512-T5YaUZEJv0XHL0VYuP4/Vg+tbQGgRq0+gqsbqryuU5nq59PPISDED81zpCSb1jkZ/xFNc5Weq68+54cUGndpQg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.1.tgz",
+      "integrity": "sha512-wjIkWDEzv3vvUnGtQi+bqQOrnDcuYszt/5S4e1hycctOYP2LloGTW8I7ehP8arnfPb2Du2eiPGXBy3dVGPa44w==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.0-rc.7.tgz",
-      "integrity": "sha512-smo+6QWddCdtLQb4AUVbaaxsu3h8ImQlMDTBYK4qeoxlVTQdKgrNdgtQe5YoB8bvuGLQd6obVVwwScPNaD73xw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3s0w6rdRzaSfTEC3wJXhsSzT8GdIAkTeuwWLxPDGF5xQLVAvx8gAPNgnQ75PSJWF2H/jeZ8rfTNGHYF/AZ5p1Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Iuksc3q9Rpwj+EQMoCv9BqfLBEclDiUGiGwUec2p2FhZjr1yEBK4ujlQK2N71EteyBjQ5yODE+/S+TzNkrou9w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fluiMLoPFtGnt8MBMoPFzEgjzGQJpUJkLbEC9OQSvBi6MXiZk5oOas8fwH4ZwuDgw0Ef6TIBFxOsbnhfLX6A+Q==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.9",
@@ -1927,241 +1860,236 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.0-rc.7.tgz",
-      "integrity": "sha512-HrFy3NpBx8J1Az+4WCljgXQvt/TTa6G3SKgtF0ZxdstB+BYoiMyBjO8aXAKQ94BM7zLcOVfUmL1bCb9t6tFmvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "clsx": "^2.0.0",
-        "react": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.0-rc.7.tgz",
-      "integrity": "sha512-XTKDLADe621GN+D2ysnOdVFvK1Et4nxvdrvsCxl7epsfrelsZD4l+/BleUQ+G/vQVZt3v03VkVVnE0SPGpt9Fg==",
-      "license": "MIT",
-      "dependencies": {
-        "react": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.0-rc.7.tgz",
-      "integrity": "sha512-+8TmQprJ4y1J9AyM+/ABkndWsv6/lwA7by6HlRup4Ks2auQBhejFG7FjZPFACjkWLuJaIgDUN1aRQ5MNFCanfQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dsWyiL5shUua/VdQ07p1m6pCNlMkC9Rqr40bjgvFYYqHHvBchqUV1uKWBKSuS6QYSw/yRdk8hJOPtGnXtVU33g==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-client-web": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-web/-/dsh-client-web-0.1.0-rc.7.tgz",
-      "integrity": "sha512-1pb5B7V8vhrgoCFsBwa8A+MsXkPvwPJ8fJ5ldMZ4Cd1RyFPgVev48LW/z2WF4tc6qkots2wnjZ2i6bMz8wvk2g==",
+    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fX1uEFVgArjfkmsBzYWbmg9bKYYlmF8UVH2QDp7AgyXc19TJF0I4kFMD1IH9it5hwUuZvPOIQynfnZnwT0YenQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.1.tgz",
+      "integrity": "sha512-NHbAXB4JfQb3AWfzF/bcRp5aq2ETDx33oWALkW4mGWZi/amHap4WWibmkhXENc0oibJ8ji9AFj1k87CVgHsCVw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-schema-form": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-web-react": "^0.1.0-rc.7",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-client-web-react": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-web-react/-/dsh-client-web-react-0.1.0-rc.7.tgz",
-      "integrity": "sha512-aw8s6RgMVJNNPTHB4TzVmKsuROp9yZDMKKXsMEEha8CESlHhCF1c+qxLsjAcilwY5CYCwin2T/3lot88k+ITiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "react": "^18.2.0",
-        "use-sync-external-store": "1.2.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.0-rc.7.tgz",
-      "integrity": "sha512-jNY9OOSpcH3csXqCwj8MMinByo42aUVIEauTSK1tNIOn6h6q0Y7SPu1ObIo5i3k0Khh/OWIiBTS1SbBlxcJHjw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.1.tgz",
+      "integrity": "sha512-w/z8Ng+RRzRrrTodOU6/LjuOwaN7KYOiooxlfCfKqf3S3PsGWzUrvLTsenT9/SCa6W4K3OI74y/m1J2o4xAgWg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.7.tgz",
-      "integrity": "sha512-vzW82eU4so0qJQ/XS7BGBUSguJMAgEOW3GaJJW0g+W5ysBJg+UC/Jjo1Np8mPjSpjjl4eoyXpshJzrwjoxCpRg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.1.tgz",
+      "integrity": "sha512-uha3FJobyShXIMfSuyGCHatbcfY3PA4mATS+hu3JoJy/+9w2Hbish89+eTZBysA4XEG+FRzVVdz9TbAHP3UR9Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.0-rc.7.tgz",
-      "integrity": "sha512-CEGOMie1k733yc6TCSZuAtgbcs5H2QPO9wZnDnkx/kqaj3W+cEZGz6zZvljYNMWspNpomDTqOqpcB4ZAOI/K3g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jVYt42fXeAgujQ64BznB8FUveil4D9u5cfYXCnTz/cMMpTLNlDIeF8Puj5b30w9Cn1B1AlL088DFxlE+Hk0F+Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.0-rc.7.tgz",
-      "integrity": "sha512-zDBNVlCAwnieffyctzqZ7hUGLJqyTjqvtCEvzSNckmd2owyuYNPDIeFu4NTo/xN8Z/TISiuGbgA0wnIBCIsNtQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XETnZp1RAgLMM4oRJxFmIngQMJDT0Sm521GaUfdVLAXhu+BKJxXVcrf4WkhhR1zMZdKYl7aT6TU1IvTNH1H5uA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.0-rc.7.tgz",
-      "integrity": "sha512-DM/EGrz8vvgRJSxV4UAWtyJpxFi1v8gWkj/iT9q5iGex0zNdDO4Ml0/u/e73brmN3bsGyubsdUuIdkGsl8n/Ig==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-bSSh+Ac+z9JbIoK+guAvX+XUR5avWZrGA4/bTMv3zB1C63+CnAaeU1UgYEV4vDR+sPVZRexPXXx45uOIicQAwQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ezuYaKmblRkOaFLUpzrTK9DiTrbES2lBtmkzo/Fg4UteDHLBVEaBgoips0J15gXJm8mE6o3LHhsgmGCIdNepKQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0L0vLmCnz17t+eQGMzq+SrYqBm8OWlnt2xOQKNKR4oe0w5HYaqqNuxEzz8bjVvrazjr+hv3PPQj26uCPctsaSA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.7.tgz",
-      "integrity": "sha512-SYrQpJZQ4fvfyfw3IJ5j0goUiOFZb1ZhcANgUp99HVlhhN/l1oEOAvEZL1efaSE7KIG6qp4JEn7iLtNdo8+mEA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jOtQNe5RBfyCQxUqCAhqJbrfM3iUZZp1H197SrhFDuZT8v4CbbnyjBWQTAeuztf66pM8VoCxnBik79kY6tN/KA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.0-rc.7.tgz",
-      "integrity": "sha512-9SDsfhfOzriMw4AF/md6MDOjl+YOwtE9BKFwunCGzfyWZnOUljoKEZxjtU0w1sIESSAjJnTicqb2NBOAIV9YQQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0aDCK6TDF2RXJTrgkmuh6KAGLA8jthR3JKNp0be5RS1U2IIEXwjOLwr5ol4gvSaNLerMlcyLyslkATrHj8hQVw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.0-rc.7.tgz",
-      "integrity": "sha512-c4bkTsJMKeDDgN3F9GBvEJCnsaLyl3I+uXb42rBPhOzH85bG2x55fMO9lBhtpvE5h5JUOP/tBMtTAW2OCe10Mg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dNi5IZg0nOUPckhOSgEltHpF8On+wEkMR4gMVF0YItYJifReqcj1qHDZ+8jjmDNFTT5lnOUXylMXyY08IM1a/Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -2170,44 +2098,42 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.0-rc.7.tgz",
-      "integrity": "sha512-W4SbSgHlAhCB6ZXjr1/BdRiTn1F1x5nZdCY+0AazHoJY9FDACN0hUd6Rlkc40n3x0BHxXN/sZFDHCtT/26Fw+Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-pRFLE04eJRkH46NMH4F6HvCz7lQMxdua2MifcyAdfuHLRCfGtmzJtlkNJkHd7936rJqHaRmVUz3+UMt86MbyBQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-token-meter": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.0-rc.7.tgz",
-      "integrity": "sha512-D8A93lu2T1/QfT9yRErxI3ptgTyGwJUIorzf5WQe4+3/buv1LUKCXJHabm0fknaDiQdUOge+MjdZDNV2SoYGvw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-XunBtjdTo5chATPwwUDNLfz7lIkdGxn4OIEHZ6WQnXl6sCgd+xy2pCjBH0j6wdvWO/xo7m99FPnlOCW6cyiing==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.7.tgz",
-      "integrity": "sha512-A7R39cSNsLwjm+P54bUFBUd5+YbdyKkC5cLQqYt12STt0Z06az10Qt5rsL25rnWkxW7x7Ql0wVA83tOmO2oy0g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PUyFU5PFleIvjxTZpA9v9Tq9wCsESzQnqwhMU/Ir+CKtSM5EcMsQPCRD4HHnFqrVCIsQYyDffBbWr1K4LziIEg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2215,31 +2141,31 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.7.tgz",
-      "integrity": "sha512-24oY36x90GN3QG2BASlryjzsO5eLA1U9vsvH1tPtBRJ1pBC6JqnW2v0SfDI/pcMT0ZbWo0uEATiik8rrv6xRpA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.1.tgz",
+      "integrity": "sha512-oZPts8lYYstp9XE0N8jYziEQQcv1+8B/BkKfT2pr12/7SeQjAyduyIRlSOmc/UFWEz254BLDWI4vtnWXkJVazQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-3HB4nHXzR3HreJE4MfVSX45Am1/JiKFSDOYmrnyX7kK3Hvb9qH1J2Mm4gCzNislCemhZ+wlYQgevrvyH1L1PvQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q59hxIpWTHHrFmYS1k2h/d9aNEKrq0SA8At4sxM0Hpx6/JRBqvb2AwR+m61eOvwBu2HApSY/oHjrgrG9JukQSA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2248,31 +2174,63 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TitE4FzwV4JPWmXpI6Rinn+oVt+0c6DtjJCXdapafNHaYKUnYqFE4Bydvn2hDzLKnkwEgEKEugSZLRno6P91bg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference-local": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+aLtZet2Al71eRKeFIhYXHyogYLvN2jIRcyxPF2BirhwIms5wIkRQsvXdJJPKr1/p/7wi4pS5FmQifDR1Tq6Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.7.tgz",
-      "integrity": "sha512-l4jEcfjrV7hWTQo6sH0oXntg4pz1nVuDXRcprps6NhZ0/OOer/9SzUx7J9aLnLeX9XDtExXsFbxkXW5Js3ZFwg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-cf+F+spDreyKTFYPYZ5DshRJuq5+H1Wu5xD8078zjy5PO86ROZRIvQl1zc1D8EnWhGSL/8rw4uCuYkhIZNcicQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-gbiH8xBrBw/1iRM3MLwI9zlFqLRg+1d+hNs8Etdn240xjWPuFdv5Hjg+eu4V5I+lU3M/lZieahEUpwYRScGuVw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1vKUUxl9gZ0xh/wniBs0e4/h8+BEBHuBrIhpgf4Jr1IuPJIQbzTDgJVvFM9657zWxdNzcmb+5QV3N25GWcayvQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2280,39 +2238,39 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-UbLBBWzUfBHAaZ6xGY/pPlIemGKz2iPoiCfmMkFQeLXVlLzeMrsTY4mvdx5ywu63tKYHvPpHHGdXMRFHqrTBvw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-CsECIJkcYcwfXpQa/8stxEdGifxa/2d2AJcUD/ILR9NcHTr1rR0UjyJ6dZREtEhclLz5HrMois6qdf0r+TCo7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.0-rc.7.tgz",
-      "integrity": "sha512-QMv2QbqVAKkFAmIIPFmW8cvjk8U9T4ZEVsoPdbanw5Enrg3qEYZUmii9WBkAxNtQhG5MRUf5Tg8jDkZqPScYrQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-tfWU1aVZRxW5j/A9zEaPQUcs//jf5XhnR4QAmAOXtY3EvgHXEXjaJnd9mfKquMZtvZEr+4JWVJo/aj6BERch7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.7.tgz",
-      "integrity": "sha512-/pI2o0YcP21ReT+OQx7aA8SyUsnuEHxTQtMbu3DvN9ChvaFeptCTXGvHWocwVtzEEi48mdvAXF4Mx0Ptj1LJYA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-kvrZVsyOe1ZDgYyFMKpdhOqn47lMMP88wac66suQrMPLI/zQeHPv7sTnQoV5BceQsWln/N2Txe2iBXnmDxgsQQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2320,49 +2278,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PWIaza45vFqqrf8bYyw5tPgEXRqLliHqAn3uKEwui8b1hM6UHJtApq1jX83PO4gtJZs/yAnRK6LCbaS5VJBC9A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-BscFM96Ud1/txqIJD2t/atqTrUmlDLd29K5fGhGmm83pOB0lHqCJ6T1mfoLrT96KIU8+x04ubkfz/63xXjGllg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.0-rc.7.tgz",
-      "integrity": "sha512-EKn/wrMKgqxPUPwLgoTGk3BY8vFcYSYBWfXxnc8ZOKiH2pmprKnzm89AcOkbERNBJzPySQEsDdSoWwWJ2Mut4w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.1.tgz",
+      "integrity": "sha512-4ktB7lef5PXUXy94eylGwGCYwMOCGjsfj7WE3H/Zcg5yXs02rZZvE2P4PHYaNvlnizc4DDlwJpyNCc+TI6PtnA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless/node_modules/commander": {
@@ -2375,130 +2333,131 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.7.tgz",
-      "integrity": "sha512-9Bu0eAbPw/FfCNpiX9hvyP5wedMUUQBc2sVTtU+xtH27/iUPxXoamFtBt3ydBJUeuVhja/leuhJ/d3MRhXO9fQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.1.tgz",
+      "integrity": "sha512-C83S3PL+S0mEC66nJO/VFsdkG9x41tSGKmrZdanTCA5OEp/M8OJYRZNYmsUl48Xwe8wQfLhHOes7FVWtRDRcMw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-oBCIJzzvVXijtxAPqSlQUlYTywEmkn3JEpMB2PM8W4UafnxNhqvDh8ikGE7/1y6KWoFUS4jHGwerUzyp3C6oWw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-pVyVP82Ij14kniqMDHGm/0Z+DDpkwJ/qHbLGe/G3zh0fpONPznUnYc8Qy5S88S7LKJy5+lLv0T5C0P8w9GtmEA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
         "fflate": "^0.8.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.0-rc.7.tgz",
-      "integrity": "sha512-CamVZ4wOjGcgzOiRFQtG0J0hy4EY3nXJBRFs0S397+H7b9eJUTtaMdOxP5w7VhMQ0Aq2ND7gpadwIcFaqINsMw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PrlnIxKg6WqPP8WwBVQf5TNRIxhb0cuEEj7JX9eI/rycVzNSRmaeJ/vTyoOVnw3lUZeI66nFF7PAOgJz0Ojn9g==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.0-rc.7.tgz",
-      "integrity": "sha512-QFuI5xGvVQAtbgN5xEZddM9+s5/2GWem8Gvq5hQpi1faUPyY/GS34B3lpuui0khSyS2NTa5GUXtYhDN1qZTVjw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9WDce848S1mUkswZKiFGS2xqjWBDYakg8xJoTtGp11b0xcgjITJNYRJLTrffqZ/FgPMSu0Ij3nn/ypBBjv+Xag==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.0-rc.7.tgz",
-      "integrity": "sha512-yVHhAPK61gurrgys+xKia3RCr2OlwFCSb/XGzSDuzkVtAmqtG03oWTvnMiNpRKUyGCRFdgN0TP3QDg46rRlQ/g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.1.tgz",
+      "integrity": "sha512-6KfMYkD+XUSUXjGff/EGLjpPFjU3lDeWoFzyCde7g9aLy0RfEYCSAJtcXUCZID+Z3PPwIfssFCwPn1H5ptyFHA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.0-rc.7.tgz",
-      "integrity": "sha512-CMHnPXL0oqwCnwt4TVRBAUfM4GNwkcZ1yURLlUo11ISBYh11LbOCXri3LoDjXzdCaZ21CWEKl25sZHnHnQ2GWg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dZs60Hr6MNJGzroTrQ0I/FD6IDcHwBFiyYSoU2GRunWKz0tdKLWAADHl1eT4mfQay4VBrl/58E+9T5loYWtuFw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-native-command": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.0-rc.7.tgz",
-      "integrity": "sha512-qSKYgM2W5EV8mE5J3OEujTY4z7mRwPBCRK3hQrl8vm4IAuSf0vfv2qrS9rpgU2SUrpHlQCqsu44bp8OPX+XeUg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.1.tgz",
+      "integrity": "sha512-efJSWiHOCPZYG+IAE8xR6Jm7x9rnO6HH3TYsBffL6T2vYlxwpPD7uifUDgHVvyVmPrgAMsPeYhI/0tAtZm+nJw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.7.tgz",
-      "integrity": "sha512-B8ITfMnBAdgkkuvoMrBdVgydhsCYGnP8XIGXIouOQyT9/eWbD3WqO76XG+u+e2G36ACXu2NaIxsRh3ijzyorwg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VKQPlWcxQTKZIGDvf/yW36GGk1iwbMLFIyWYr8Q3iRCYSlGyL+JL6ejJClxboVNWiZvPM75Ywai6HgkpLbLgPA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2506,28 +2465,28 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ip6HeN9YpWJXgWKAWsL3JUrI8j+MHEvbQ/m3U5ubP/Pc0AQ9x+6xZ/nYe+22112I12rihiwb85ykFwFfx0QbKQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ugps/tmxbOLqbAf1s5sCIdfrlLpm4rHKm1OyCCNbKg3MB1YoZRqa+hH40Usf/VxzvjtP8AVDYzcYnF7vwAafLA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.1.tgz",
+      "integrity": "sha512-tRsr9Qynl3qnFAHE460uALI9jncaD0pr4+hufWTSY73MbOswd6V3KDYy3wWQb9ttDm5XE5GTkB/a56KNnO28XA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2538,65 +2497,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.7.tgz",
-      "integrity": "sha512-+omM89dEsaiAL1XtsSTMmRF46POp5g25Qs5KVj+Zfrk7whlXjLXwFiaukt/htdVdHIOM51qM+tCleqlHOU0Chw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-LbETHkXkI92vTQCAnOqsmt+W2pagu0PlVw15vGTBgks9xi7YweFQtGPfsiCJ0EHWaiKARvqtT+dN/n0KkDyicg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-DAC8i+sshAkXPI8IcrUp5O6cOOkLLsKsD7mAcorFFbQjcPVBLdeRmtko3E1J9Jmf79IjoAvKVE+J+y84km9yKA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-xjzJy3yhqdUDTo/IRr7cGpnE1wzVRF7ZABcTiCg2cNeYGY5SzGoUn/XyE7kOsPEulHbnvpr2pddHMJvwbBcGPw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ATVyi47hyAWFINOxi8TGurRF8rShW/WzqWKqjxEQU5gLZbWtAMgkpAc+hwlyo/lXytGaj5cMXyzeyjpD6URHFg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TKrXFGcAibVAWoqjlc+M7xRfr8IVdkzMpemmSkNpXOxaqLVr5KLVwAOL+Fp05knp/riV2WX5POucWJ5L3P3gaw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.7.tgz",
-      "integrity": "sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SzZ0WHjxyfcB1j/aEkZM/P5Sd11qw58AgB7TFcRC0iHwZtAqlKMgaptx/Rz1olNyerGpjii2mmUoinF5p1MYwA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.0-rc.7.tgz",
-      "integrity": "sha512-cWNbBF+LeFrexht5V8cFeo4Kb0KeFaQWtemPJeTHRcijafq4OuQvgJEPx1IyelzzX6vctLQGSlmvvCNesLvIcw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qCtJgnvY6ix3hXX6tRcVozoi+JL8re4PjpNnCGYz3Az4csqdIkL+a9DqnV8JOIMi20NTjeOrktaOFgUd7rdsDg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2604,19 +2563,20 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.0-rc.7.tgz",
-      "integrity": "sha512-8sZuvgylK9ZKQmZtUU4z3DVBcM4Q4SH4OWo4qeOahLOsteT9NdIwZFer6f0QwqH6DjXIqz2Gq+XtntYXznGZPw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.1.tgz",
+      "integrity": "sha512-lExsZIY7PeL7yEwgglTGLb1Tbg4soANFpuePOONIrn1ZP51DwENw1SrU/0RK9ps9ksMHyl9J1ie5FIYS/YCY0w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2624,37 +2584,38 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.7.tgz",
-      "integrity": "sha512-yyn5Yqth6vdScgmcYDF7L3a1jbfcu2y205HyTx9d84H+eU+h9m8k0Mc+1l8VCJbv9GILPCvoijP8wFTPDas7gQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9bluPgwdzU7HIteYvwmLThzcT40nUBWDCrUkn7WjckuWnlx6qCIz5cFKeh3iyPPIHvcD3jidMB2ReOxKTEy4VQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.0-rc.7.tgz",
-      "integrity": "sha512-hjdki2TTXfyZMJuddOVXV0lEhZjdku2aoPagVKV4TOhqz3jDJE0mQds87mtDOI9J4pyRGWfYXky6HN9Bi/usgg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GXifDFUgiWcm3dr2Cbnpi9mbQgzP3GtIpGSX+7RlXlCHIHuavXCdgvGHSbq/KGPM5vAwrkZS+xcLwTSqpQL47A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2663,18 +2624,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.7.tgz",
-      "integrity": "sha512-P/Inw7dQMZCC6I6NC6G0UF9SeOVlpQxOBg2+LoCdvyTt40itDow2wmlThqkQDIt4UMHLT4yRc0Gd6a4gmTNJ2w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.1.tgz",
+      "integrity": "sha512-uG1+QqnlA7pTLj9ZffQRfIbZDrp7kHnquWotqZkc4EjLF2sCwWDB7YHYhhszjTbfOY4QAWk3tWvcszC0bV1H5Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2682,40 +2643,40 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.0-rc.7.tgz",
-      "integrity": "sha512-c7NiAYPx5Ho2ZYOODRvt0yTZ9l00n7QvRh8paiyLaYBOuzo30KDo5wTJXGLxMkfzi6EQsWw1tljd8MnpGL2P4Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.1.tgz",
+      "integrity": "sha512-maVhsVwhIyGuqcMpJWMv4BPc/UaIIdAT4aZmdv9bHzbj3vzRALjAKOEAdhIXtdxtuTKcYbimg402bbEwe/u2OA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.7.tgz",
-      "integrity": "sha512-bhmSfXIaLWLrYwC4ziMZ7GkNy5i9ltGBvlNZ5eB7NZoDAMh0Du7pKkMY+oqm2ajvx5O5qiFkHEhYoypRpEB56g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FapYBIWVzcXioH/lTaBSJlbEM9VQKzSy4fQgzRDLAVP8pMAHAvTaF/tBGQMooP582sPe+XpGh0xwWSJ5X72h6A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AC6cyrinc3fQ2/TKmm8V1r/32f3VekR/w6rS1+RWGefRm6PDGnNo4T96/U4EoMyWDq0VBCn1Oye+uqhWPtl/3g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TSWcoxXBD1PQg2btZ7cMscQSHBLAz480oE0PV3ka/kgrvBgppwtppQbMoF1owPek+cJ3EraXthXnUk6IlcuPoQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2723,50 +2684,50 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.0-rc.7.tgz",
-      "integrity": "sha512-1XhQNi3pIQ9TMUiquo+RRS4VpbXYhpFmZJ845kaVGToAexS2gJRVte8i/wKaDHDp/huAhJIsZemHlX0qADDsjw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RrP0ABGoVvy2G5i8B5nssDpgpFIwNGvdT7wPPN5ID+wnRe1TD8PwfM6L7ZsTpNHKlbpmZmNfRxlEE1cRm89XVw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.0-rc.7.tgz",
-      "integrity": "sha512-VXUxBvmZ9PYinVbYsu7GmT8BZMXCfAbqExNMoR4RoZm+leOLzZOkWOKea9THoJwIik0lUbAO5lzrqaeVKa99Dw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.1.tgz",
+      "integrity": "sha512-VtmkzVxwYShRNrkN/1cdLIFaph2vQbm7o5/8hK3elXVYOTd4Y0q3H3LduPMmu1Ejnj5trDYqUTZ2A+vPob5ZzQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2775,203 +2736,200 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AImknM43+7bIR9BzEatmbZMvhjgBgAt7MWqJzmTo1KnBNTY1j7r/RmOiQTBX4R+tpsLXMza5oW7svHSAYw/ypw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Wl60ol6xE51HXjrQznD2dlvU7aH/mkKjKwaL5rQ7M/1bfmqOEM9cCFVAGw4uFH1UIwoBF7Z6lDTfdgpum8eFjA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.0-rc.7.tgz",
-      "integrity": "sha512-mXJcllRKoGnFhVs1mtUjjmqdfMymTRif5lrtxdhlkpegH6E9qKF7Wyq1Wnjkpsk6QW/iCicrRkXF2Bw623eDag==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Sh1M2I98i3bPmLmQdhmcbjOTJltRL1ygr1bSx46XR94Dqwa1DvmCx6P/ZPtI9I5KQ05u0Lq4omyfTJ3R0twhIA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AdG/wyhpWSJcLkRqs3j2VVgS6uH5xQf0mK7WZsdQ/RidB3OVYZiBg9Mto7Of25AtV5lP7ZN6TrqCqWgi60XwFA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.1.tgz",
+      "integrity": "sha512-b5DPzJPJTKACT2RNmdTBRvo8ajkJ1n+UttlH5tULaKepr6AdTxxvq31a7HFWMwmHJ6aftXGyui+g7a2PSCW9bw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.7.tgz",
-      "integrity": "sha512-he43z39/SC8cMzPDsoP7EEXiXKjav3VClj/U943pxycvRL78JGkNEQQjv21n5mnuto0ti/gFBquybSI4sBAFqA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.1.tgz",
+      "integrity": "sha512-+2udF/TLxmZTgNC3RFA7ydN2sD/LIAjkao1bUiU372uOTttGrt31kKbeEqXL9yzfdiLjjuXWhRlbtmvmrf5PKA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-jahNeS/WnBinCisOB4O+zeS366v7gWt6Uzfso0/C5He/vZFEITW5jPfWrJkZLuuN5S55LshaDEnegsddEIp6kw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GEFDzS1sRs1ISeWa97jtr3s868WlqEnP8S1w6y7stXIBm4GHzrLizjF1IvYlxh+WyE0rBC5wa0kVSZsjRQT2tw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.1",
         "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-TnOy1SnnSNPVZyw9UFNwQ7eE2lGxQBU6kye7+aAwDbNvSnudCJDEnQJhjTvGewHWA6PYA0O60XERKcCQAnK+dw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0CxwofljyZEAwrP5DboMZdm3NfekF+bDu2A28IWLTkTQKgF4DCekQ4bMf+Nqsc0gxBiLfo1ZcUUFICQj8m6mMw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Br+Ocg+dr1PcCA71DxPJd7/7Cel+HLnRyglbkhSPx9mEYpXXgioVCkDHJh7J9OvjRw19UF56g2CvgVah6HwFww==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FG6dJCb37vcuujAK1E906v08jtWTV6+54ShftCjqauHXWk7YKtIAsYRwMIkXg32aPD11EvQGtoJE45Rs3XBEdw==",
       "license": "MIT",
       "dependencies": {
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.0-rc.7.tgz",
-      "integrity": "sha512-vlvjvhE2B07XG3X+jUsfEDUjsiEGln8GFdy+ojWm27FKtA8JuoMdrMMUcCuVHnyr23jyk2Ft/qGA3JIJUOvIKQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MvX5rP21/K0RqHTYdyMJIUqpM90En3A2CQiCiIc8BDzFqNJQgEE/+PDeHsxXnaPatmLhC2Sw0fQnZaoJxZ3/WQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.7.tgz",
-      "integrity": "sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1Zt+tWDSCoSTAzbaJdSiWHe3pJTpyIqnsCEP3SOyxLIKclsj378rhsrkw+5O6oCRxjDCf0u8BJ+Q5liXREedBg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.7.tgz",
-      "integrity": "sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TypXRsDxHQzms8H44DYFOs3sD/1fVvpFcyPMtOSP0SY+u/e+P/xg/0PgCvEt1epigHkBXtHddjHNLMlhzy9mbQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Gw8GDvEJsH815NQuKkWhPPmw61hqhcdVpaaTXbCTAq/+0YdgNzNxAGIzizufAmq099QsqVWX0zs7IWGpWzCfEw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RC4X+QWL+mYIEYmkUrd/Jca6y/qgqL8saXm+v9pDU+lhjZ757qpUc+2WNUo168cT3umTLEYOcDnLty203C4HeQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.0-rc.7.tgz",
-      "integrity": "sha512-yToQnjzMGl5KCq//k9bN4OUXxpyRRjh3hBtnf/9AVVSvvV5DGDLHryEm7erECLOnoWZnng5J5SDERcykrVbYlA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ZrVUSq29taKCbpaD5crG+2XRWyJvNQhFtbdxSqwaroWEsYdQHINVqn5Zjf/Vm40n4MWiZLWDbsNf8ba+CWE3Nw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "react": "^18.2.0"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.7.tgz",
-      "integrity": "sha512-NFH1uIGQDgMFOijgAv8lLWRiY3eHFEZW2alwuHlu4C32P4+jdChh9fjPlzBar3ZZTq0ZW0qWCdbYZS02DNxsvA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.1.tgz",
+      "integrity": "sha512-EsgGSWPEt+pLBamWbICgISNOpw0f1FVdECOnkbHVL47weOTz04S9SVdLcZv4aMo3xSONbdBAThhhh8DBf6Q6sQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.0-rc.7.tgz",
-      "integrity": "sha512-amPgKP84E99YEiOroeoQNya3Rjm1VRWWU6y0ft02iVtFohTmWRMLESArkAAtFfap76bk34xEkvujp34nJl40Ow==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.1.tgz",
+      "integrity": "sha512-FvK6nBwFk+tBUIvxL6QVpck9TVEG73HC9VlVvc9VeskD/74/J5FinubqjtER2S5QMVHBrocDy0EkGYqHrJlTgA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2979,29 +2937,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.0-rc.7.tgz",
-      "integrity": "sha512-BXehLYt6wYnV0PNNhv5GECePkH1w+1yuu/R63d2tdYdUQ7XVrd6tu5hMwfTH0P9AnBDxJir08FRu2WKO69JypA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.1.tgz",
+      "integrity": "sha512-RXDAUdfi3CqTQGQhMyIDZ5u4nURmN0ChkWwoX5Ph5rITa1zelnQsskYc93s+FTtB9Ituac3Uynk0rKGw/bS4fw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.0-rc.7.tgz",
-      "integrity": "sha512-qWf7p2Xgr0LnY4o466ei3L/81QbGFQcCbEi+4XX9rxLKgnU+RvlQzwmIilrgz9N2hK/RqwS1Nb03bFRisxVeaw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.1.tgz",
+      "integrity": "sha512-eWdgco1blIb+hCGPx0bWy+cc8nebhifLm8FsXrguIJFgK499HZEhDpf8D0veRgmpjV0HhNVMinB0egdXNeg0nA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3009,26 +2967,26 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.7.tgz",
-      "integrity": "sha512-JKlEpByllYQU9JZLadrS3ClWCVZMcKRB4nc6iCWuNExyRi/Whwa5GicKFs+jXwGKe/rdSbTCom/jYLwkqipjuw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.1.tgz",
+      "integrity": "sha512-5FX2RunFkHNY75mCK1wrJ+uJkETWzV+p9tbao+L9V23Q6njIYQ6cMZ7QxvCHcMpqZIUvD1muZweau1e3UIB8hw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -3037,19 +2995,19 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.0-rc.7.tgz",
-      "integrity": "sha512-XuhVkX2V+tx/xO9/gCzPHGbovoApwaojwCjNFAuBUbHLMvMl1wMdxvxSgk/xLPKnll98daXRPoq5Csg6hrG8MA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.1.tgz",
+      "integrity": "sha512-0qQdWu3n6UPSmOe3FgdELbqOa0aohbcD0TSEu75Cba2e7I5XHQzeKsFas552zKiHmI7f0BconaLKDiHnp7aHgg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -3058,57 +3016,59 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.0-rc.7.tgz",
-      "integrity": "sha512-lyD9VbGrOSVkAV8mr6aIl22bdWIe61lC9/dtZ6CtS3DLnewvSkZ4CNlUDG/qS1SUIZfk7A2UixgXYBIB2771xw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.1.tgz",
+      "integrity": "sha512-deO+kFcK/ZOvcOwp5wd0tCPL5/yiv8TeE3Pmvd5NqaMr/0vKm8ePeoXwqJmQ+T3cHtbUhukGNvFKiP94IdQaHQ==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.1",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ryf7HSYdmLbrTv4HQmeW/h0bHLiCNnSZYiY9RoBrzg2qh89MU8S+Q/a9CLVWA06TRXKt7tNbizF82dCj2/O0bQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.1.tgz",
+      "integrity": "sha512-H+JqPsq69nnoNPTJBQVQzG8EIVb4UZyyN4teLhEal79LG3XvYn9s/ZWTus3z02//KdwGhetCzvPZ+E1PVaUFIQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.0-rc.7.tgz",
-      "integrity": "sha512-6f5U7nt5Iqwh5RAFBqV2Ib7LJU2o89Et0r0eV7bskYws+PNM7ZRRW/Nw4a12ZcnuTp1eKPyVE8H6oJua6/7XLA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-sZVe8bnMZK38J9pZWrObXOFKArV3aKo4cQJ9TgSmo9C1oAY2Mv0HA8rOodUCBX2u74zQ+LuB455iM9V+SCHBXA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.0-rc.7.tgz",
-      "integrity": "sha512-k5zHavA2RoBtZ5igD+qpbdfyxKvesZa2w+YKLfMtUnZOj7HZM9qcxvfYo4xJ9spNLpN5OGY/sWZBB5itilZlCw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.1.tgz",
+      "integrity": "sha512-GMWUdtmqGOakCbx0af2umlrHzduqypxSp3ozYi1OA1KOqxKX3aiTMilcaOQL79/e+/Z0zG4v2PvXKCsa2grAzA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3121,18 +3081,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.7.tgz",
-      "integrity": "sha512-jhFiZa/C58zchuJkBodnkiPil7AEK8mHfB/hMOAW3N/7tUg5nbMLBERNqHdDMbIrvhTndrF4SN9qy+ltUf0cOQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.1.tgz",
+      "integrity": "sha512-hPtDxVSktufWJdZKE5c1tWRl+lb1NCRcjdXi+Pm8Iq8a0D/yx4YDKiv/aLhklDFybyV8FmtlVUPdJS0teyRyHQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3140,34 +3100,34 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.0-rc.7.tgz",
-      "integrity": "sha512-tFocCpSglf69VC6a23R9OcomMBQdfQZm8MvAOGgENBzWz9htDLuyq6jukKzPdTtS3VdRDu4wzJtaWKAYBUCX4w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-BUGmy8sT1IjP0S7slcfBbbjNUxcbSTN/iPPO3itSu9Gvwe6we9PwMEdVQgKozNsaUeax95aunl1KRxG7LbVKUw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.0-rc.7.tgz",
-      "integrity": "sha512-mpQo/1x4jaWNdQAXckOs68U59u+/WHJlb/BX1zAvr02eJPV3Wac2/7NP+/vTw5TElEyzIAU8k0f3PMgvozUk0g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vROiHtfX8VBeRKfDsnFufP23iZHjxMKUC2Fvct9QbWG4iohaAYT8fAfkzyVcZTE3Mgr1AuSzIiRtiwUUheiZtg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3175,29 +3135,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-title": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.7.tgz",
-      "integrity": "sha512-cS1+StK2xIVykrskw+KrO+hKJxYaVVgY2Jex2we5zASTNLHYCj74WQluPlaFjFgnXoZ1RYz8HNXL5/Ho6h1Ynw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Q7dr2mQQlaAOgZR9UGUQprOQ0iI/NyrsfSWO612/teUawfXaf6k1nO8w90ExDD483wengXp1bnZ1JT7bal9WTg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ODz9QWtCOjmwX7gxewPBfIHkA9twPiHDpcwgAW4sQUztgsJZKUtoe2T47loNH6QlHBPcSL5WMP4/QlnkRVKC0Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.1.tgz",
+      "integrity": "sha512-2W85eA92YLsSNBuQHDcmrK3ycWqz//Kke60vlZ1Yo7rCLjxLhCLttEPxLdpmNsmwOOxAQo0KWst0tIpzglmvOA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3206,73 +3166,73 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.7.tgz",
-      "integrity": "sha512-in3ifbq80tn5cf1ICBBsRdwKjURB0g0dIRdCVUgl/GDqCdC/S0TjMLXw4nmFdCssYLm7JbG5a59BfJG0KFuz6Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3D92e9P6qEfLipJvTSzg5voTLydjxiC5glLJpW/1Jg2HZ3OFJ/sr/2GOIjSNNYViRYOXK9HsfvYURUAFHmQGTg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.7.tgz",
-      "integrity": "sha512-joSBNw/d54gq/VjkHLGSJ6y/Qr+594sObF4ApbJi2eEopx41L0Ky7kNW/W7cbrGIIN3KBGRDdiGv1s1paWzsMw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.1.tgz",
+      "integrity": "sha512-wDBqqaXbUggc8mxhmlO3aWoQcZ+VCOIY715L1NhKBi3FmEpmDm4XOoArs8udH1IBUKYIQzp0GtDtLpTccPohOQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.7.tgz",
-      "integrity": "sha512-tDaqB1TOs27fSt6FZdjvPs4THXAFKoKOEgQG+iFUv63O5bm+glyLY3K1LTK8JeofB4lg3+4JIAeWRslnLJH57w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-jc/z3QEYGuGlnh0w/kVv08B0vkiCVmXhX62MppSuzK6yGKQQJAYtvw3Trk9q/hYutL3KwFpAK4FnJ8dtmiPB/A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.0-rc.7.tgz",
-      "integrity": "sha512-01Ue3mvLYyBwNj+fAuTUZN4gJLuDySPDqAZhCtWoYagZudCuLB8kAdpYWztKA4TRVSyml+EfGo1LrWvQeTD1wQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.1.tgz",
+      "integrity": "sha512-7evQ5D6krRUbf1FVt1HutKDMecZDQqmGbZBe9ohhGrIQHU12U4Bewb5LE4Tl6A6hKKstnCoY5SbovQIbm8V5lw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.7.tgz",
-      "integrity": "sha512-i95xycP3vkz4IZnIO4BTzGNB6waKl1M5AsW2x04C0FIqLa4BSILvVUVwqcbwpBZm7Cd/KF50Q050au3NvauGrw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.1.tgz",
+      "integrity": "sha512-ReGxRVmlVJ0S23lEPWlADnPie4Sff0vUdjt5/W4h1o1wZLyXG4STrCoa4Nkm4Rhx3ES5WfLa0Wr9TPzTkLEieg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3281,10 +3241,10 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-home-paths": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
@@ -3316,65 +3276,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.0-rc.7.tgz",
-      "integrity": "sha512-EdX5AZElelHlCKlbflZipl4KRDiEHWLN/8smgnkzAhJgpXFq5dyp9jK58dO5v7cuODeq+/SfeDyUE5Mffdhh8Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-PK1A1YxQVgisWacljbHAyL2z3MGXE+GWeXzNf2hHElzmtAkv412a3TXtMTL5XLZ1m0laLZxstEcf8L+S4zxvPQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-jx198A2cc1gxsoKb2pRmXnDbIwIHAKg78ZjRMyiLRGpOFEZugVudILdDMp8u+lGpavP9xVAxBc1n75Z5NDRw7g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-YquagM4ZY6p1+03BSJxfp/rK9yy/ZkfZ0yNumiL5juF0drte6OqUj6YvrR2/RVhV88Id85fv6ik0As70x9l+Ww==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-fYypZXcXFkXybf8N0tz70+XCtxvnn9mDN8JiKnTp2ZNhXb/zvFbdf661Pp45lFWS6j0cHZsdZ5T8DfuQjfO94Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-shbTUw8Cpq+X5XZlM3G8q5pPDmXnNgyW8NRDUg2l/bPLipdejIivs7T5dLLXKRtxhaD9GB6Z7jqFuy+dlV8iIg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.7.tgz",
-      "integrity": "sha512-M+6+SOjWWcfYoGASBMx+b1sHmWPFAHXF57rE/Mew9k5tHC5bEV8+owWwYOWQfv41eO1FfRMibZd0rH6mwPNApg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.1.tgz",
+      "integrity": "sha512-22Hg7hTTbr5fBYRXJ+5O3aBSHHfBLw7jKAPFWjp4HYziG6xXbnIa93QqgaNxz4rdpjTN9ihPP5Rc/zef+HwKOA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.7.tgz",
-      "integrity": "sha512-UxXwoCB0q4+/F+zddvi8I4LknTIlGD/1ec57Ym52kWRb7a8qGgrcIYrOC3yPCozn8rkirAuhEAkyAhR6AO5QDw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.1.tgz",
+      "integrity": "sha512-7p5qTSxunIQzzKOq1mVIwGh/USHuSuphHEHx3TTu6c+4Iumd6njZ4ijLsw4QrHDUhlGxWaTy9d9Ga/x6Wu4mAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3382,49 +3342,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.0-rc.7.tgz",
-      "integrity": "sha512-xYvEY3+ttxJg4/UPzXuxgeKcLxKvDP4alvPpEfRwuMBcp//O6FtzEJSqV8zycJVYHU8V0wmUKRIn4V1ycXlFgA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MopZ2No4pWKV00BRQjBuGzaphx3YuNxQ4dCKF8ktDkGYdw/SOEjsurl2ejr2YoXUSLTPWpImEquhkOdRWDqAeg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PEpA9XT6E4hg7N8m7GYQyDLwFUwoqWTz0Cm9SrdAoNcju4byG08qy4+muDZbG0a1tm3PR4rxNB5zKcobDhDocg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MhsAoQc0KFvZyNzEsnrWRX1DwMlgPZ6KeTRUPdMwfpqmCcLgNmz36dl2OdiuUr71kbQyeF6HHO06EvrGhH1Qhg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3454,173 +3414,174 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PnT/poBisBmA9U+mLZeyQJfHS4Ps8kwN1ioZEmv36TwnROCrmwzog5FB33r9rXU/gKVX0dD/LkjxxTGmzC1xCA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.1.tgz",
+      "integrity": "sha512-UHuipiCfXPHrdcwy+Ck+2BzzW4l9IH5HsiWDDVrURsIvCaceFq6jWlaR1Fv3/1iylEl8FmOS3u5fHlLrBYo9qQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.0-rc.7.tgz",
-      "integrity": "sha512-YleMt6xtXmW8LkHZ95MLPq1urIt1+sBUK908GCQ2EhV6nyfUwNog4XVDlVbzf3GXzc+3z/xiMW2GvVp3IQ5NIA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.1.tgz",
+      "integrity": "sha512-zp3HCvf8EPz6Ey0tD0d9+q6FeA0eVTvlBo3+N6m21+SrF8fp47Fb6kFgJ9zoBh4vNGXZ7bDZ/LOhYg4TlotBQg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.0-rc.7.tgz",
-      "integrity": "sha512-4C06MeBvsbgiUrWh+tge91wRLSOOJDU/Ub7b9Q6nTxQKEMJooJwCQRPfgaWtdXuNHrJGIJ87GKsgqV2iwfQ/jA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KPC3gU/gc2Oxh0pdzOL3Y1czTeZLu34jJo0YVaFFToQweiDwCUL/6nBLWq3S7nEiDL73hTG+u2lca1/ShaWg+g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.7.tgz",
-      "integrity": "sha512-xiHD61S2trIZ0CzhSMgXxZJVyJ2c76DkX4eqP3Of4mBEnm6C7g7FChII6uL0z5v1bnOnTmpHzwPX8YCwqb7dbg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.1.tgz",
+      "integrity": "sha512-SXd/WT2SddMYUhCno518bmOdv6SqH9OX4X/u2uVzgT793UJ1bNtx5UZiTIox3jZFZXeSj+snthuzCiZfnA2j+A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Q1zl35fRNSASv2FOi6viwR29cn3vtOcyKfamcmRB789m6sb6CdlhIMettvcxxDDHwTSH/jjz3hqb0JAx2GT32g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.1.tgz",
+      "integrity": "sha512-y3omlRw0rE8v9VrSp+QQwzVca7fXp6UbSuW0klsYsC9QxEMx6iOSXsZyu8ZKLwd2hh38uY8GspzB8oTdXqpiHQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "koffi": "^3.1.0",
         "node-pty": "1.2.0-beta.15"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.1.tgz",
+      "integrity": "sha512-YILPMh2sfwhcK1ijr9ll7TKVQPwhhfrxIFl/Kdi+LIeLiTlOOnt6krpGnlXfzRPu7SzpNnwcetKljKOrHtY2YQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.0-rc.7.tgz",
-      "integrity": "sha512-B22qppmKWvw5Ez9eMKnppHiaMrikIcHmfmvyd296EspnhTBJAvXDnc9NggT0DUnSvm+2gh5ffohhMJel9A2pSA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-34Ef13Gt5NG+W+u5Z41tt/TPBNFwMfjXBCy3ySSpZw/8b6KXDs2KwgLtrfBBBOSB9wV8ONtC5DCCEsOvRr+u9A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.0-rc.7.tgz",
-      "integrity": "sha512-2muS7xmy4olNEpGANp0ViK3/r4A4UlfQa5w24HJ2PrCy0J3qlk1vwHrpj30nAGK6sCaxbXmb8IjYUfNs7st7zw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.1.tgz",
+      "integrity": "sha512-m9ADv/ZAMI1uubj3zihD1G67Ql2pzrc5HeOUPx32Iwq8autKqj5/Jef8QnbUgQsqNAlLHodhuLroTJbKPv42+A==",
       "license": "MIT",
       "dependencies": {
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.0-rc.7.tgz",
-      "integrity": "sha512-rZhEYA/urMq8sReaMc5rb9A/p7X1MXwktoF5Y6SwGUWqJQsdvHzXppksOEqJpg4a1pNDBe2N9X5o+wMKPmukMQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MIk6ID6LDDaP0NstVY0D36+qIzB1X35fC85PXsTr/b8g9ccu4GVod6ohunnhD6RcHQ76qHtVcKhtu+AoiFpebQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9JURjw8lFbSAQogQiN7KvNAJc7WdUMdrj1PkcZEs3y0rMuTb4Z0+l0QS628+BzmKzB2ndZs8QO8VJSMTSdpaIQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.0-rc.7.tgz",
-      "integrity": "sha512-DYoWGpJglqzWxCFDzynJ7ebt9m7Redlm2Iuon5U2tJ0rsyOSRIgKuwQMXI67FdN/MNVXvSQ2xybUqu+5V0krnA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KvAviVyFybH1Gh08PLBDMV2VFUqVy1Pf1w8I8tI/EyiuHiZ3R8WXfYs4qp/oGN+n/atCHmJwkicR67xpG3LHFQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.0-rc.7.tgz",
-      "integrity": "sha512-i2WOx26otsAt3sTFOoXjo2xsdvUyC5CAuNiJyRQoo6yn1smx+NX541clIOYdx1uneZFmV0T6bK46JpdXasxaAA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.1.tgz",
+      "integrity": "sha512-P5CIwXRbGUO8AquJIuoZaLlBY7NZ/OqGM7BRM9Qps+vNaC3lmwa/Dq/I+fhmckXjPMYLA20X4kVVn/SDUG422Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3628,100 +3589,100 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.0-rc.7.tgz",
-      "integrity": "sha512-ZqwrTw+w4GepNCVQ7NIq71s+Hlrqu3jAfYCdKuNbkUy461EjlRLGMcHspSHAt1uhdwL9QDTodB6RRhpg65Hozw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.1.tgz",
+      "integrity": "sha512-MUXpZ6BYy/rAY8Yp+NXXwbH9Cxlria4GGq+nbnYaTHpc8xM76X1hpp3n2iOzV/ef9V+IDCWmW3Z3gnljbDFWRw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.0-rc.7.tgz",
-      "integrity": "sha512-nfc0SI3Xk36rgIOLmTBDSrSTN3Ufp9Wvefta/M82kbBCo6fesB4lst+VAw74039jzHUboXc2gwQ/j5rRcOpiuw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.1.tgz",
+      "integrity": "sha512-e083Qn7V8oESrvMU+7oC7wpj16PgU8/fXErgEsSyxFIY8e5qU/+K1jWX1B2SvVS/bpE7+nm3Lq2jNDFpXZ6+Sw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-5tMC1TuWiGDerYd0UuUUzRdmv+uy/22lXbxmmrmUfR8aACeK6T76yXorvuvJSDYjhPpLoUovz9XU5LqGm3D2Wg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-nbEyHaldIFH0XSZwGGqTL5TC9Rw8EsdN/Yy3ONxu4Leo6evMP0FhwND2zOD2ORTrp5R2lqLaLWcz2c3RZWF8Nw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-terminal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.0-rc.7.tgz",
-      "integrity": "sha512-GKmrKxwfIhk51dEEzWjvPKTZ2SK/RNxKXROAaSsZ/HGcerv2kmBHRCEPlaphKBoWhFuw7KAhDnzI6foXLg4BWQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.1.tgz",
+      "integrity": "sha512-lAd+eRth7mhr/SRb8CFz9OhS5arF3VQgnrWxfeftE+oofytj8juiwppSBXPfjl1lP6a2D5jVsQ0G6pd3pdZCXQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.0-rc.7.tgz",
-      "integrity": "sha512-tzZ1A+HhfqkMyOWwPgkWezY34rrK/OHD6BBX9DZ4km5/545JZ37+jmViza4TwrUhVxbs+Szhrx6g6V3Hm+674A==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.1.tgz",
+      "integrity": "sha512-NvBKLiR/mqLP+pLulayPH8t1bmOYFGoUGUR/V5hUP4GjUpS7sCrR+PH519N0lSRgxghx9Q1YrvC05M2wcfV5vQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.0-rc.7.tgz",
-      "integrity": "sha512-/Uf2z6OZckk0Nz7XjVbzf/yUnvDeY58CkUjAqy2FxgGuNc0rvIR6VzRER5NZ+30bXeB8TPnjMuCVB+j/8zltrw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-T9teZZdjshbc/J+nsQV7o6Jdp+q/A8tYSx3FHP5BbN14T8tlyd9F7FWccicyNe4uni3e6ZlUfXjE3Qx6c1epGA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3729,22 +3690,22 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.0-rc.7.tgz",
-      "integrity": "sha512-0Lo6bbpPcSMKZlWkBGx2KjwyLy5zYJKMH8fmwz8orwOKHjbfYQT51GV9cpdhLq6NYTwKeMUaxTZC4xPlZ03SAg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.1.tgz",
+      "integrity": "sha512-aMSfkvvrvXI7uLcLb06J+WR+ZjdAD7ROswC3g/l4lpMV7h8WuRcEp5uCpdxuMrgQ6bqNrpDD5QT/KDU8d7VE3A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3752,185 +3713,202 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-spill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subprocess": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.0-rc.7.tgz",
-      "integrity": "sha512-bQTVYD7nAtddefQZvvoKsoRHehA/hAHIPbNRdY+L97HVwKnowg5rlcUn/v+MJFQ1NPaTrTAfVQiHXGKEeeI9tA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3SRUmWx3Q7TYlg3ySDiWII58Df6RivxkF2OHQUxJRpjHboJJsoO2YwOAFFoaNij92OHvXKhB914w/FKbIVqz4Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.0-rc.7.tgz",
-      "integrity": "sha512-n/YcmHVTBrN3soZqzMElsnzIQoClOS3U1n5oqpg+oPyesMehpp7DFjdqh7kCZGEmI8chtq4AhYsPUWTPo85G7g==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.1.tgz",
+      "integrity": "sha512-yW+4977eNR/ZjYlEMhA2XgY6pFR+Rj8DBoZV4bG+NKWGWXec2gxML4UzdC/EVg5qJ/b08P07/3MpdjfEBCs6Uw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-output-retention": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.0-rc.7.tgz",
-      "integrity": "sha512-J24DC4otd3gAVvJ2jPpCfxrrujB/5isEqScp53O2vSvFP7rKn/Rwo8ddr1v462JVWyUG5HtyKpR23cPmQrP0+w==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.1.tgz",
+      "integrity": "sha512-dyKAw1z960cfqIMaZwXSCDY4LIZ9w7RlWxBcanVtCNXUzqac8qCVvYNoXGnJ5u9KTjdfYyxp9uAmlvdQIoe9eA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9+LWvtD5fucgNF2QzJJgFFcBHa/hvtQvPqGy+N31w2BE2lXogtFZBwWRdfH1L4Fye3F0+37l88xs3coZY4RONA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.0-rc.7.tgz",
-      "integrity": "sha512-1ZCj5w7GRcbs0zuDiDpZLJKc1zs/WSn1WX9VWTuXvWocV66Rq8GGMZLGDksBeltd+jv/dym7xro4+xFl87059Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qJMzBfmljqpm1BiedNwdfBnuvWH3+5N2duC/x1hGA3IodHQ1Rc03hVtWJnbB6GYctshJbLRft7yLnNTO6ghgNw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AnXLgiDXq8qB196qq4LnJ6rC5ukoPA4WZH+ILSFpLm59owkfwJLS9rGsfP+PGqiTN7NhoZtAwGmZoYCdSDi0kA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.1.tgz",
+      "integrity": "sha512-1VDrgqj3I+I+LmqD+B1RTb0zU7uZuajjPmczCNQAV0zuLjTIbwiHne7G4gIxm5CE7uXlxsSzZnF7ZSuYKF1m/A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.0-rc.7.tgz",
-      "integrity": "sha512-p4GmCg5wC9uw9BaVK9W0hOnEnjGvhhRF234ClVnQMbHwzfgPbhc0eSYUNJQmouqxLAa4kVuiF0nVZvc3aftCeQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.1.tgz",
+      "integrity": "sha512-4P4SKqMUeEq39Dcw7oXenIMKlkyp3lwvchnmP9shf/fRAs5nAxDPMja4Wb7sEXQkVaBF9pUUp7GZPhfqhFIGWQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-QWs7SeItxpaJ3zY5Vh0scAv84QI+ZRyg9+dws15H88T+dp9dRr4gmR+fqEUdwd9JhPJF5VIORtKY/MqVtaiYQA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.1.tgz",
+      "integrity": "sha512-N2FSHL+IsjBUTKsOeVuu4IrERuLJ32h8Zp5TWWQ7ONy+yISnFZqkmGrx6BB55HsnM4OM1fzVcBME7+tVqQ1tdg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.0-rc.7.tgz",
-      "integrity": "sha512-VPWUrhTc+X9DcrM/WC+ikM7vCjW54KzRU9wfdhFbXD6hea3hBQ4AlhEdtFtRwmgv3HmjYIUgHkPA3h7pqTsB1Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3Y4G1s4ebdAwln41Jike3Rnp4k4d/v47PQVFlk9hVJvbrt2C6LGLM1Id2C4+30Hi6JPE4EaO3wIutkX5ar4aLw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.0-rc.7.tgz",
-      "integrity": "sha512-bdDcRsiB9t4EILfA4gO+FWwXrj6SA12SP0nqymz5yOI5AJWR6pzuIOwRk7IdguHBzq8pDyfelw0YxN+EtkS+tA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.1.tgz",
+      "integrity": "sha512-TbtTJEZcE0K3UU7tbkgpTy3T6bJrn3SGyzpSiguiPkqYSh2i3qi4kHKMgI2fH5NlmznyKI2EmWb9Tjw53zxgQw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Jm00eSYvNq8Qj5GmXdsC7EY3Q6TLSzBTiODNAu2bs5HxEqE5ssQ/fdcxuAXAfSFmh2Vq0ENLZckDg3q5Xvj6Qg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.1.tgz",
+      "integrity": "sha512-j3gZX+p1vJYrJpPFaXiyYSEQf8rpWbQ7sNJASRCFR2Q3a3rGHXrcFVr4A7WXH7zgIHwcNKK4FHv7aDAk2JuMrQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3938,17 +3916,17 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.0-rc.7.tgz",
-      "integrity": "sha512-FJyrD+LspCOIP05/v9hv6MJNkTbgDw8ZpmyAXk6sRopA3yOUju5SnN5HpSZ97ZAK65T6tHYbTMdJhy51D41wOw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.1.tgz",
+      "integrity": "sha512-d3/9NJQc2Vcv4m6Q94POCRZ0conqjAeqUobNwIpMiWrSL4U8jZYzXwFVBw0Sw+cwYVBi2Og5Vv9aJmWANTX3Mw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3957,56 +3935,56 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.0-rc.7.tgz",
-      "integrity": "sha512-EF9qbGiCK+SdFhckVcS8o4F0Rrib4VEbt5yCe0njj4UrHubjz5Ldmz68TqdrvFqw6mvQ11SUqAm1ookp5hp8gA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.1.tgz",
+      "integrity": "sha512-KS7BF1W6fGFgatMQ7daCRxSDH3zG14ob3s2b0Qzb0chZAIbxVe/DcQi2xTcK0MpXr77RKikdHUgU6n/+arC+pw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.7.tgz",
-      "integrity": "sha512-7Kq3EEv354aNcxbS0NRfxxyJiZhCsvFV/03a3MdkYO/gG2eM9+E4xQum0N2FL5bw7JiGlgw8jdLMkcNGmavEaA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.1.tgz",
+      "integrity": "sha512-vvb7G/DR/guhL1B5pMRdmi44YQedeefp02Q6pkHS+MgjNl8N//CZFCPSxSX9kX/a8R5/tDQZxxGsZdj6vcC6zA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.0-rc.7.tgz",
-      "integrity": "sha512-0sU6QDo5/8/F7eIi9YGOqI4PTz34O6+NOUr3qRK6U3m6YWh4SVzn1Fc5LXqpnaZPNQpetuLnkvTvFylewBghJA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.1.tgz",
+      "integrity": "sha512-8NKYGmopkroNhPtMbTc1Xdx5twz8VxlV1fVie22LgxmS5c8eP2Q5DQc8jV5A/5tePYchsC+FpeNSPMKUgzkO4Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -4014,151 +3992,161 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.7.tgz",
-      "integrity": "sha512-R7qdvaRRHbz5xijoVOxueeBB/VT0eDzuQNQN4iNEBUbI/L9xG9bZutktTQlgrIlBSn1sPH4pLqiCiM6ErQPTaQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.1.tgz",
+      "integrity": "sha512-bdPYdYDNYgTGgEkHCIEB/QUUTXo0r5hkEyWlh+v95Qe34B0ZO3KhYTPSPaoYDwP0kEaOwtmmxNGZd8HFJ8VQnA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.7.tgz",
-      "integrity": "sha512-7AQNJLNZTw7/5DzjbfBy4dRqr6VSwc74HBOSPpxm0zzzbmXOEqRCRzMps25IByoAeltRz1ZyY4fzN3tcYa+XwQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.1.tgz",
+      "integrity": "sha512-9kavDx4n2dxtDNU8uPpoaB604uVBST2aA0TvcR5d+GTA7/vFgqmT2JjQv5PG+GwM+JAO08MsP2ldWMB+FPo/Zg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.7.tgz",
-      "integrity": "sha512-kYMpU6eg1m1BcfSC4FLWUcNH/QAE8tcu0WRkQzqzoCw8bK/Nl3dqHtd2qSVzI/emIviTulM5I230e4wPi/kuVg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.1.tgz",
+      "integrity": "sha512-r2TkC0JJGQ8EOyTH8DXafbcj080NdNbVzoNERA1pRTrH7+ZE0PHU6MZU7xGy7cwAKmAUGnm1DjF8UHOQN6ns2Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.7.tgz",
-      "integrity": "sha512-dfT6pj84lJdhrtbW2pV6hRftoKDkqx0aJevrhUhOy7Lv3CqTOheuLwwyT69Lww+n/q80Z+yp41qJq9loCkrOaw==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.1.tgz",
+      "integrity": "sha512-q5RZczXTNzSC/fas+qIno5jCqH/jotz0OpBzRCTNMPV1ID4YcGroaUKsLxzaGXP5bbiaVlX5Tqt5FUYO6rYStQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.0-rc.7.tgz",
-      "integrity": "sha512-v3Wx/Kn57RyLDqvEhmz0m0p4YluLGSabmMp7dRVJSemYUzT6ZB0JCtMhWkXh6O3kNHSBGpfxeY9Pk+8k80X11Q==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.1.tgz",
+      "integrity": "sha512-fYJ3epKwpY0zO61a9SshY/gKmrcfP7N9EX7/VUGWdpE89jKg52LkioZ5QQ2cKYatbPUHLWx3H+llCGmqOf4bAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.0-rc.7.tgz",
-      "integrity": "sha512-hcpVwEk5/SgZ63TRUmGaQsC1p2zBBSO8/KAr4xfM2XSwq/tbvpMLrkyt1zehBXcsx6ijB2s62bsr6AYOz9EczA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.1.tgz",
+      "integrity": "sha512-qV0Djh/9lhdBMlkwry8x3Fu3pckiNur8OiQN8cIRvGqyDrJ3yWBjJYga491OeFEmCw/QF9DbfKgmU/O8r4gzlg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-app-boot": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-connection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-modules": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-stats": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workspace": "^0.1.0-rc.7",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
         "@deepseek-ai/schemastery": "^3.18.1",
-        "commander": "^15.0.0"
+        "commander": "^15.0.0",
+        "open": "^11.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-shell-env": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app/node_modules/commander": {
@@ -4170,87 +4158,130 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.0-rc.7.tgz",
-      "integrity": "sha512-U9Neu6x2/0hrDwCeExEjGO9KkXiJEoJgp61QF/XQkaHyg4E7YSWZDG9NttlhepqFgqs6Dn/qcjrL5G0JGuWYeA==",
+    "node_modules/@deepseek-ai/dsh-web-app/node_modules/open": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmmirror.com/open/-/open-11.0.1.tgz",
+      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-client-web": "^0.1.0-rc.7",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@deepseek-ai/dsh-web-app/node_modules/wsl-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-app/node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-frontend": {
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.1.tgz",
+      "integrity": "sha512-LxKEcBy6npgLXqrg1utA4/OZocXrx1tTQaIK1VH1l2vNs0vN6fOKSMpbvbUB0mW0RKxXmHg8NfJ4JkdliMtIsw==",
+      "license": "MIT"
+    },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.0-rc.7.tgz",
-      "integrity": "sha512-NciK9Tm68RK5XOzl+Jcr4+eG6M5Svq1/23Mhjor9QVYPW1J+wnyxUt6RKLIrmjyiS6VOCOCcZVtyITFkkfVaSQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.1.tgz",
+      "integrity": "sha512-3iQHtGsPYEi0r2Zd34XO+FayTPrE9PfPpwnHSdvKy0MdfGqjEvJyujh0V4X9tA8EhW1eGXzoOXIIKzVOxxdmTw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-credentials": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-web": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PRGT0iF2KcOTxDC1DDIrNOe9bID3zZms902ScrxGAGj8AksRO97kj+3U2MOhRPfHkkNhSQMHCLt42DiclYhWtA==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.1.tgz",
+      "integrity": "sha512-Q7Vq+oqklhlM9XeQp+LmOZDWXCvxSQHdFjY1p5DxUOgJgLCcoNe+0QsOwH7VHm99ZfTtGisH/t7oWx+m7fbcHA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.0-rc.7.tgz",
-      "integrity": "sha512-v0YIoPylB1SJW5gBV8gaqoE0PCAZLzEgIU5OqckBKiApHBd0jIo7EzCeTW9+9Tzd8gwwcBQYv7Yxr++rmH8WGQ==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.1.tgz",
+      "integrity": "sha512-i569BFPdkc7OU/kfcJvRH59GGz9wXmUR5pc6pPVZLNkpPvaqiOgThnK3D4wSfq9SkxuzK4026IwITsUJF2poig==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-subagent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-workflow": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.0-rc.7.tgz",
-      "integrity": "sha512-0czW0bI+uFFOS8h8eJ9SGZSdv+StEsa/+E1WEjZQXVeIOxo520Pv47dq+Z3mTyBfV8gJB+UcY0AQ3F0FddYohg==",
+      "version": "0.1.1-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.1.tgz",
+      "integrity": "sha512-rdw8ovh2C3DlE1UyQUUFv+U5b0JoNveypWlldslEjkwLQTO8zKeZE0HGPEGnIwHPz3wYOr/jQKe+mbKnFQ94nQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.7"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh/node_modules/commander": {
@@ -5649,9 +5680,9 @@
       "license": "MIT"
     },
     "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.5.tgz",
-      "integrity": "sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
+      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
       "cpu": [
         "arm64"
       ],
@@ -5665,9 +5696,9 @@
       }
     },
     "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.5.tgz",
-      "integrity": "sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
+      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
       "cpu": [
         "x64"
       ],
@@ -5681,9 +5712,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.5.tgz",
-      "integrity": "sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
+      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
       "cpu": [
         "arm64"
       ],
@@ -5697,9 +5728,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.5.tgz",
-      "integrity": "sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
+      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
       "cpu": [
         "ia32"
       ],
@@ -5713,9 +5744,9 @@
       }
     },
     "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.5.tgz",
-      "integrity": "sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
+      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
       "cpu": [
         "x64"
       ],
@@ -5729,9 +5760,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.5.tgz",
-      "integrity": "sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
+      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
       "cpu": [
         "arm64"
       ],
@@ -5745,9 +5776,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.5.tgz",
-      "integrity": "sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
+      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
       "cpu": [
         "ia32"
       ],
@@ -5761,9 +5792,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.5.tgz",
-      "integrity": "sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
+      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
       "cpu": [
         "loong64"
       ],
@@ -5777,9 +5808,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.5.tgz",
-      "integrity": "sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
+      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
       "cpu": [
         "riscv64"
       ],
@@ -5793,9 +5824,9 @@
       }
     },
     "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.5.tgz",
-      "integrity": "sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
+      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
       "cpu": [
         "x64"
       ],
@@ -5809,9 +5840,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.5.tgz",
-      "integrity": "sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
+      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
       "cpu": [
         "ia32"
       ],
@@ -5825,9 +5856,9 @@
       }
     },
     "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.5.tgz",
-      "integrity": "sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
+      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
       "cpu": [
         "x64"
       ],
@@ -5841,9 +5872,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.5.tgz",
-      "integrity": "sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
+      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
       "cpu": [
         "arm64"
       ],
@@ -5857,9 +5888,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.5.tgz",
-      "integrity": "sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
+      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
       "cpu": [
         "ia32"
       ],
@@ -5873,9 +5904,9 @@
       }
     },
     "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.5.tgz",
-      "integrity": "sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
+      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
       "cpu": [
         "x64"
       ],
@@ -6724,106 +6755,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@shikijs/core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-4.4.3.tgz",
-      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/primitive": "4.4.3",
-        "@shikijs/types": "4.4.3",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.5",
-        "hast-util-to-html": "^9.0.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
-      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.4.3",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
-      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.4.3",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/langs/-/langs-4.4.3.tgz",
-      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.4.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/primitive": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/primitive/-/primitive-4.4.3.tgz",
-      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.4.3",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/themes/-/themes-4.4.3.tgz",
-      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.4.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-4.4.3.tgz",
-      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmmirror.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT"
-    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmmirror.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -6838,9 +6769,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.33.2.tgz",
-      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.17.2",
@@ -6905,12 +6836,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
-      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
+        "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
@@ -6962,27 +6893,10 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.9",
-      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
-      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.17.7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.7",
-      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
-      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "version": "3.17.8",
+      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7086,15 +7000,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmmirror.com/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -7109,41 +7014,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/hast": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
-      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/katex": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmmirror.com/@types/katex/-/katex-0.16.8.tgz",
-      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -7181,12 +7056,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.101.0",
@@ -7462,12 +7331,6 @@
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
-      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
-      "license": "ISC"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
@@ -8081,12 +7944,6 @@
         }
       }
     },
-    "node_modules/anser": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmmirror.com/anser/-/anser-2.3.5.tgz",
-      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
-      "license": "MIT"
-    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmmirror.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -8389,7 +8246,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
@@ -8449,16 +8305,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
@@ -8484,36 +8330,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cheerio": {
@@ -8633,16 +8449,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -8796,19 +8602,6 @@
         }
       }
     },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -8848,7 +8641,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmmirror.com/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -8865,7 +8657,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmmirror.com/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8878,7 +8669,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8906,15 +8696,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -8922,19 +8703,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -10131,46 +9899,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmmirror.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -10187,16 +9919,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -10409,7 +10131,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -10454,11 +10175,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -10493,7 +10225,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -10691,31 +10422,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/keytar": {
       "version": "7.9.0",
       "resolved": "https://registry.npmmirror.com/keytar/-/keytar-7.9.0.tgz",
@@ -10740,30 +10446,30 @@
       }
     },
     "node_modules/koffi": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmmirror.com/koffi/-/koffi-3.1.5.tgz",
-      "integrity": "sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmmirror.com/koffi/-/koffi-3.1.6.tgz",
+      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
         "url": "https://liberapay.com/Koromix"
       },
       "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.5",
-        "@koromix/koffi-darwin-x64": "3.1.5",
-        "@koromix/koffi-freebsd-arm64": "3.1.5",
-        "@koromix/koffi-freebsd-ia32": "3.1.5",
-        "@koromix/koffi-freebsd-x64": "3.1.5",
-        "@koromix/koffi-linux-arm64": "3.1.5",
-        "@koromix/koffi-linux-ia32": "3.1.5",
-        "@koromix/koffi-linux-loong64": "3.1.5",
-        "@koromix/koffi-linux-riscv64": "3.1.5",
-        "@koromix/koffi-linux-x64": "3.1.5",
-        "@koromix/koffi-openbsd-ia32": "3.1.5",
-        "@koromix/koffi-openbsd-x64": "3.1.5",
-        "@koromix/koffi-win32-arm64": "3.1.5",
-        "@koromix/koffi-win32-ia32": "3.1.5",
-        "@koromix/koffi-win32-x64": "3.1.5"
+        "@koromix/koffi-darwin-arm64": "3.1.6",
+        "@koromix/koffi-darwin-x64": "3.1.6",
+        "@koromix/koffi-freebsd-arm64": "3.1.6",
+        "@koromix/koffi-freebsd-ia32": "3.1.6",
+        "@koromix/koffi-freebsd-x64": "3.1.6",
+        "@koromix/koffi-linux-arm64": "3.1.6",
+        "@koromix/koffi-linux-ia32": "3.1.6",
+        "@koromix/koffi-linux-loong64": "3.1.6",
+        "@koromix/koffi-linux-riscv64": "3.1.6",
+        "@koromix/koffi-linux-x64": "3.1.6",
+        "@koromix/koffi-openbsd-ia32": "3.1.6",
+        "@koromix/koffi-openbsd-x64": "3.1.6",
+        "@koromix/koffi-win32-arm64": "3.1.6",
+        "@koromix/koffi-win32-ia32": "3.1.6",
+        "@koromix/koffi-win32-x64": "3.1.6"
       }
     },
     "node_modules/leven": {
@@ -11162,21 +10868,12 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -11262,16 +10959,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11279,247 +10966,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmmirror.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-math": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
-      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.1.0",
-        "unist-util-remove-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
-      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdurl": {
@@ -11562,588 +11008,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/micromark": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmmirror.com/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-destination": "^2.0.0",
-        "micromark-factory-label": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-title": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-html-tag-name": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
-      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/katex": "^0.16.0",
-        "devlop": "^1.0.0",
-        "katex": "^0.16.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -12302,12 +11166,32 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/node": {
@@ -12687,23 +11571,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/oniguruma-parser": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmmirror.com/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
-      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
-      "license": "MIT"
-    },
-    "node_modules/oniguruma-to-es": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmmirror.com/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
-      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
-      "license": "MIT",
-      "dependencies": {
-        "oniguruma-parser": "^0.12.2",
-        "regex": "^6.1.0",
-        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -13109,6 +11976,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.2",
       "resolved": "https://registry.npmmirror.com/prebuild-install/-/prebuild-install-7.1.2.tgz",
@@ -13145,16 +12024,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/property-information": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
-      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/protobufjs": {
@@ -13351,24 +12220,12 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "node_modules/read": {
@@ -13445,30 +12302,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmmirror.com/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmmirror.com/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "license": "MIT",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -13562,7 +12395,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmmirror.com/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13632,13 +12464,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "peer": true
     },
     "node_modules/secretlint": {
       "version": "10.2.2",
@@ -13820,25 +12650,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmmirror.com/shiki/-/shiki-4.4.3.tgz",
-      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "4.4.3",
-        "@shikijs/engine-javascript": "4.4.3",
-        "@shikijs/engine-oniguruma": "4.4.3",
-        "@shikijs/langs": "4.4.3",
-        "@shikijs/themes": "4.4.3",
-        "@shikijs/types": "4.4.3",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz",
@@ -14008,16 +12819,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmmirror.com/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -14124,20 +12925,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmmirror.com/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -14428,16 +13215,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -14680,88 +13457,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmmirror.com/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
@@ -14846,34 +13541,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
-      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vitest": {
@@ -15840,16 +14507,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmmirror.com/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@deepseek-ai/dsh": "0.1.0-rc.7",
+    "@deepseek-ai/dsh": "^0.1.1-rc.1",
     "dompurify": "3.4.13",
     "markdown-it": "15.0.0",
     "node": "22.22.3",
@@ -233,7 +233,7 @@
   },
   "allowScripts": {
     "node@22.22.3": true,
-    "@deepseek-ai/dsh-subprocess-local@0.1.0-rc.7": true,
+    "@deepseek-ai/dsh-subprocess-local@0.1.1-rc.1": true,
     "esbuild@0.25.12": true,
     "node-pty@1.2.0-beta.15": true,
     "koffi@3.1.5": true,

--- a/scripts/patch-dsh-llm-pi-ai.mjs
+++ b/scripts/patch-dsh-llm-pi-ai.mjs
@@ -7,10 +7,10 @@ const packageJsonPath = require.resolve('@deepseek-ai/dsh-llm-pi-ai/package.json
 const packageRoot = dirname(packageJsonPath)
 const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
 
-if (packageJson.version !== '0.1.0-rc.7') {
+if (packageJson.version !== '0.1.1-rc.1') {
   throw new Error(
     `Unsupported @deepseek-ai/dsh-llm-pi-ai version ${packageJson.version}; `
-      + 'review whether the supportsDeveloperRole compatibility patch is still required.',
+      + 'review whether the tool replay and connection probing patches are still required.',
   )
 }
 
@@ -37,61 +37,10 @@ async function patchFile(relativePath, replacements) {
 
 const runtimeChanged = await patchFile('lib/index.js', [
   {
-    label: 'model compat resolution',
-    before: `\tconst thinkingFormat = entry.compat?.thinkingFormat ?? route?.thinkingFormat;
-\tconst supportsReasoningEffort = entry.compat?.supportsReasoningEffort ?? route?.supportsReasoningEffort;
-\tif (thinkingFormat === void 0 && supportsReasoningEffort === void 0) return {};
-\tif (api !== "openai-completions") {
-\t\tif (entry.compat?.thinkingFormat !== void 0 || entry.compat?.supportsReasoningEffort !== void 0) invalid(provider, \`model "\${entry.id}" sets compat reasoning switches, but its api is "\${api}"; thinkingFormat and supportsReasoningEffort exist only on openai-completions\`);
-\t\treturn {};
-\t}
-\treturn { compat: {
-\t\t...base?.api === api ? base.compat : void 0,
-\t\t...thinkingFormat === void 0 ? {} : { thinkingFormat },
-\t\t...supportsReasoningEffort === void 0 ? {} : { supportsReasoningEffort }
-\t} };`,
-    after: `\tconst thinkingFormat = entry.compat?.thinkingFormat ?? route?.thinkingFormat;
-\tconst supportsReasoningEffort = entry.compat?.supportsReasoningEffort ?? route?.supportsReasoningEffort;
-\tconst supportsDeveloperRole = entry.compat?.supportsDeveloperRole ?? route?.supportsDeveloperRole;
-\tif (thinkingFormat === void 0 && supportsReasoningEffort === void 0 && supportsDeveloperRole === void 0) return {};
-\tif (api !== "openai-completions") {
-\t\tif (entry.compat?.thinkingFormat !== void 0 || entry.compat?.supportsReasoningEffort !== void 0 || entry.compat?.supportsDeveloperRole !== void 0) invalid(provider, \`model "\${entry.id}" sets OpenAI Completions compat switches, but its api is "\${api}"; thinkingFormat, supportsReasoningEffort and supportsDeveloperRole exist only on openai-completions\`);
-\t\treturn {};
-\t}
-\treturn { compat: {
-\t\t...base?.api === api ? base.compat : void 0,
-\t\t...thinkingFormat === void 0 ? {} : { thinkingFormat },
-\t\t...supportsReasoningEffort === void 0 ? {} : { supportsReasoningEffort },
-\t\t...supportsDeveloperRole === void 0 ? {} : { supportsDeveloperRole }
-\t} };`,
-  },
-  {
-    label: 'route compat detection',
-    before: '\tconst routeCompatDefined = request.compat?.thinkingFormat !== void 0 || request.compat?.supportsReasoningEffort !== void 0;',
-    after: '\tconst routeCompatDefined = request.compat?.thinkingFormat !== void 0 || request.compat?.supportsReasoningEffort !== void 0 || request.compat?.supportsDeveloperRole !== void 0;',
-  },
-  {
-    label: 'route compat validation message',
-    before: '\tif (routeCompatDefined && !models.some((model) => model.api === "openai-completions")) invalid(provider, "sets compat reasoning switches, but no model on the route speaks openai-completions; thinkingFormat and supportsReasoningEffort exist only on that protocol");',
-    after: '\tif (routeCompatDefined && !models.some((model) => model.api === "openai-completions")) invalid(provider, "sets OpenAI Completions compat switches, but no model on the route speaks openai-completions; thinkingFormat, supportsReasoningEffort and supportsDeveloperRole exist only on that protocol");',
-  },
-  {
-    label: 'runtime config schema',
-    before: `const compatProfile = z.object({
-\tthinkingFormat: z.union(SUPPORTED_THINKING_FORMATS),
-\tsupportsReasoningEffort: z.boolean()
-});`,
-    after: `const compatProfile = z.object({
-\tthinkingFormat: z.union(SUPPORTED_THINKING_FORMATS),
-\tsupportsReasoningEffort: z.boolean(),
-\tsupportsDeveloperRole: z.boolean()
-});`,
-  },
-  {
     label: 'cross-provider DeepSeek tool replay',
-    before: `\t\t\t\tconst context = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade);
+    before: `\t\t\t\tconst context = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade, profile.maxRequestImageBytes);
 \t\t\t\tconst iterator = toStreamChunks(snapshot.models.streamSimple(model, context, {`,
-    after: `\t\t\t\tconst rawContext = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade);
+    after: `\t\t\t\tconst rawContext = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade, profile.maxRequestImageBytes);
 \t\t\t\t// DeepSeek-compatible relays require reasoning_content to be replayed on
 \t\t\t\t// every assistant tool call. pi-ai normally strips thinking signatures
 \t\t\t\t// when provider ids differ, so normalize only those tool-call messages
@@ -123,20 +72,6 @@ const runtimeChanged = await patchFile('lib/index.js', [
   },
 ])
 
-const typesChanged = await patchFile('lib/types/catalog.d.ts', [
-  {
-    label: 'compatibility profile type',
-    before: `    /** Whether the endpoint accepts \`reasoning_effort\`; absent keeps the catalog entry's, then pi-ai's baseURL-derived guess. */
-    supportsReasoningEffort?: boolean;
-}`,
-    after: `    /** Whether the endpoint accepts \`reasoning_effort\`; absent keeps the catalog entry's, then pi-ai's baseURL-derived guess. */
-    supportsReasoningEffort?: boolean;
-    /** Whether reasoning models accept the OpenAI \`developer\` role instead of \`system\`. */
-    supportsDeveloperRole?: boolean;
-}`,
-  },
-])
-
-if (runtimeChanged || typesChanged) {
-  process.stdout.write('Patched @deepseek-ai/dsh-llm-pi-ai compatibility and connection probing.\n')
+if (runtimeChanged) {
+  process.stdout.write('Patched @deepseek-ai/dsh-llm-pi-ai tool replay and connection probing.\n')
 }


### PR DESCRIPTION
## Summary
- bump `@deepseek-ai/dsh` (and the whole bundled runtime tree) from 0.1.0-rc.7 to 0.1.1-rc.1, the latest release on npm (`next`)
- re-base the `dsh-llm-pi-ai` compatibility patch: the four `supportsDeveloperRole` hunks and the catalog type hunk are upstream now (generic compat-field dispatch) and were dropped; the cross-provider DeepSeek tool-replay hunk is re-based onto the new `toPiContext(..., profile.maxRequestImageBytes)` signature, and the explicit-endpoint connection probe hunk applies verbatim
- picks up the rc.8 fixes for custom OpenAI-compatible gateways (request format differences, missing reasoning content on replay), which the context ring / token stats pipeline depends on

## Test plan
- `npm run check-types`, `npm run lint`
- `npm test` (127 passed; `pi-ai-compat` and `bundled-runtime` suites unchanged and green)
- `npm run compile` bundles cleanly
- manual smoke recommended: connection test + model catalog + a turn against both the official source and a relay (new auth/login subsystem is optional and untested here)