### PR TITLE
fix: align the two-row composer bar

### DIFF
--- a/media/chat-responsive.css
+++ b/media/chat-responsive.css
@@ -118,8 +118,7 @@ body {
   }
 
   .permission-toggle {
-    width: min(138px, 40vw);
-    min-width: min(116px, 100%);
+    max-width: min(138px, 40vw);
   }
 
   .key-banner {

--- a/media/chat.css
+++ b/media/chat.css
@@ -985,7 +985,7 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .text-button:hover, .text-button.active { color: var(--vscode-foreground); background: var(--vscode-toolbar-hoverBackground); }
 .permission-picker { position: relative; }
 .permission-toggle {
-  min-width: 116px;
+  min-width: 0;
   max-width: 138px;
   height: 27px;
   padding: 2px 6px;
@@ -1187,7 +1187,10 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
   .composer-tools { justify-content: flex-start; }
   .composer-meta { justify-content: flex-start; }
   .composer-status { text-align: left; }
-  .permission-toggle { width: min(138px, 40vw); }
+  .permission-toggle { max-width: min(138px, 40vw); }
+  /* Keep the token stats, ring and compact button grouped on the left of the
+     second row instead of stretching the status text across the row. */
+  .composer-status { flex: 0 1 auto; }
 }
 
 @media (max-width: 360px) {


### PR DESCRIPTION
## Summary
- the permission toggle had a forced 116-138px width, so with a short label like "Read only" its chevron dangled ~75px away, looking detached at the end of the tools row; the toggle now sizes to content (max-width + ellipsis kept for long labels)
- the composer status span stretched across the second row via `flex: 1`, scattering the token stats (far left) from the context ring and compact button (far right); the stats, ring and compact button now group on the left

Verified with headless-Chrome screenshots of the composer markup against the real stylesheets at 500/546px (reproduced the dangling chevron before, clean two-row layout after).

## Test plan
- `npm run check-types`, `npm test` (127 passed)
- visual: narrow sidebar - chevron hugs the permission label; second row reads [stats · ring · compact] [model pill · send]