### PR TITLE
feat: add file-type icons to conclusion file links and resolve bare file names

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -1174,6 +1174,44 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .md-file-link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; }
 .md-file-link:hover { color: var(--vscode-textLink-activeForeground); text-decoration-style: solid; }
 .md-file-link:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
+/* Lightweight file-type badge: one glyph, tinted with the language's brand hue. */
+.md-file-link[data-file-ext]::before {
+  content: attr(data-file-ext);
+  margin-right: 3px;
+  padding: 0 3px;
+  display: inline-block;
+  max-width: 5.5em;
+  overflow: hidden;
+  color: var(--vscode-descriptionForeground);
+  background: color-mix(in srgb, var(--vscode-foreground) 10%, transparent);
+  border-radius: 3px;
+  font-size: 8.5px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-decoration: none;
+  text-transform: uppercase;
+  vertical-align: 1px;
+}
+.md-file-link[data-file-ext="ts"]::before { content: 'TS'; color: #3178c6; background: color-mix(in srgb, #3178c6 18%, transparent); }
+.md-file-link[data-file-ext="tsx"]::before { content: '⚛'; color: #3178c6; background: color-mix(in srgb, #3178c6 18%, transparent); }
+.md-file-link[data-file-ext="js"]::before { content: 'JS'; color: #b8860b; background: color-mix(in srgb, #f7df1e 30%, transparent); }
+.md-file-link[data-file-ext="jsx"]::before { content: '⚛'; color: #b8860b; background: color-mix(in srgb, #f7df1e 30%, transparent); }
+.md-file-link[data-file-ext="json"]::before { content: '{}'; color: #b8860b; background: color-mix(in srgb, #f7df1e 24%, transparent); }
+.md-file-link[data-file-ext="md"]::before { content: 'M↓'; color: #6a9fb5; background: color-mix(in srgb, #6a9fb5 20%, transparent); }
+.md-file-link[data-file-ext="css"]::before { content: '#'; color: #663399; background: color-mix(in srgb, #a074c4 24%, transparent); }
+.md-file-link[data-file-ext="html"]::before { content: '<>'; color: #e34c26; background: color-mix(in srgb, #e34c26 18%, transparent); }
+.md-file-link[data-file-ext="py"]::before { content: 'Py'; color: #4b8bbe; background: color-mix(in srgb, #4b8bbe 18%, transparent); }
+.md-file-link[data-file-ext="sh"]::before { content: '>_'; color: #4eaa25; background: color-mix(in srgb, #4eaa25 18%, transparent); }
+.md-file-link[data-file-ext="yml"]::before,
+.md-file-link[data-file-ext="yaml"]::before { content: 'Y'; color: #cb171e; background: color-mix(in srgb, #cb171e 14%, transparent); }
+.md-file-link[data-file-ext="toml"]::before { content: '⚙'; color: #9c4221; background: color-mix(in srgb, #9c4221 16%, transparent); }
+.md-file-link[data-file-ext="png"]::before,
+.md-file-link[data-file-ext="jpg"]::before,
+.md-file-link[data-file-ext="jpeg"]::before,
+.md-file-link[data-file-ext="gif"]::before,
+.md-file-link[data-file-ext="svg"]::before,
+.md-file-link[data-file-ext="webp"]::before,
+.md-file-link[data-file-ext="ico"]::before { content: '▦'; color: #a074c4; background: color-mix(in srgb, #a074c4 20%, transparent); }
 #attach-selection { display: inline-flex; align-items: center; }
 
 /* Responsive layout: keep the composer compact and avoid horizontal overflow. */

--- a/src/editor/workspace-file-ranker.ts
+++ b/src/editor/workspace-file-ranker.ts
@@ -17,6 +17,21 @@ export function rankWorkspaceFiles(
     .map((item) => item.file)
 }
 
+/**
+ * Matches a bare file name (no directory segments) against indexed basenames.
+ * Exact, case-sensitive matches only; ties break by shorter path, then
+ * lexicographic order so a repeated reference always opens the same file.
+ */
+export function matchBareFileName(
+  files: readonly WorkspaceFileView[],
+  name: string,
+): readonly WorkspaceFileView[] {
+  if (name === '' || name.includes('/') || name.includes('\\')) return []
+  return files
+    .filter((file) => file.label === name)
+    .sort((left, right) => left.path.length - right.path.length || left.path.localeCompare(right.path))
+}
+
 function scoreFile(file: WorkspaceFileView, query: string): number {
   if (query === '') return file.path.length
   const target = normalize(file.path)

--- a/src/editor/workspace-file-service.ts
+++ b/src/editor/workspace-file-service.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 import type { PromptAttachment } from '../domain/prompt-context.js'
-import { rankWorkspaceFiles } from './workspace-file-ranker.js'
+import { matchBareFileName, rankWorkspaceFiles } from './workspace-file-ranker.js'
 import type { OpenWorkspaceFileRequest, WorkspaceFileView } from './types.js'
 
 const MAX_INDEXED_FILES = 5_000
@@ -86,9 +86,16 @@ export class WorkspaceFileService implements vscode.Disposable {
 
   async open(request: OpenWorkspaceFileRequest): Promise<boolean> {
     const indexed = request.id === undefined ? undefined : this.filesById.get(request.id)
-    const uri = request.id === undefined
+    let uri = request.id === undefined
       ? await resolveWorkspaceReference(request.path)
       : indexed !== undefined && vscode.workspace.getWorkspaceFolder(indexed.uri) !== undefined ? indexed.uri : undefined
+    // Bare names from model prose (e.g. `manifest.test.ts`) carry no directory
+    // segments, so fall back to an exact basename lookup in the file index.
+    if (uri === undefined && request.id === undefined && request.path !== undefined) {
+      const matches = matchBareFileName((await this.ensureIndex()).map((file) => file.view), request.path.trim())
+      const match = matches[0] === undefined ? undefined : this.filesById.get(matches[0].id)
+      if (match !== undefined && vscode.workspace.getWorkspaceFolder(match.uri) !== undefined) uri = match.uri
+    }
     if (uri === undefined) return false
     const document = await vscode.workspace.openTextDocument(uri)
     const editor = await vscode.window.showTextDocument(document, { preview: true })

--- a/src/webview/file-reference.ts
+++ b/src/webview/file-reference.ts
@@ -37,6 +37,15 @@ export function findFileReferences(source: string): readonly LocatedFileReferenc
   })
 }
 
+/** Lowercase extension of a referenced path, used to pick a file-type icon. */
+export function fileExtension(path: string): string | undefined {
+  const basename = path.split(/[\\/]/u).pop() ?? ''
+  const dot = basename.lastIndexOf('.')
+  if (dot <= 0) return undefined
+  const extension = basename.slice(dot + 1).toLowerCase()
+  return /^[a-z0-9]{1,10}$/u.test(extension) ? extension : undefined
+}
+
 function result(path: string | undefined, line: string | undefined, column: string | undefined): FileReference | undefined {
   if (path === undefined || !looksLikeFile(path)) return undefined
   const parsedLine = positiveInteger(line)

--- a/src/webview/markdown.ts
+++ b/src/webview/markdown.ts
@@ -1,6 +1,6 @@
 import DOMPurify, { type Config } from 'dompurify'
 import MarkdownIt from 'markdown-it'
-import { findFileReferences, parseFileReference, type FileReference } from './file-reference.js'
+import { fileExtension, findFileReferences, parseFileReference, type FileReference } from './file-reference.js'
 
 const markdown = new MarkdownIt({
   html: false,
@@ -109,6 +109,8 @@ function decoratePlainTextReferences(target: HTMLElement, actions: MarkdownActio
 function decorateFileLink(element: HTMLElement, reference: FileReference, actions: MarkdownActions): void {
   element.removeAttribute('href')
   element.classList.add('md-file-link')
+  const extension = fileExtension(reference.path)
+  if (extension !== undefined) element.dataset.fileExt = extension
   element.setAttribute('role', 'link')
   element.tabIndex = 0
   const open = (event: Event): void => {

--- a/test/file-reference.test.ts
+++ b/test/file-reference.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { findFileReferences, parseFileReference } from '../src/webview/file-reference.js'
+import { fileExtension, findFileReferences, parseFileReference } from '../src/webview/file-reference.js'
 
 describe('parseFileReference', () => {
   it('parses relative, absolute, Windows, and line-anchor references', () => {
@@ -26,5 +26,20 @@ describe('findFileReferences', () => {
       { path: 'src/ui/view.ts', line: 27, start: 7, end: 24 },
       { path: 'package.json', start: 38, end: 50 },
     ])
+  })
+})
+
+describe('fileExtension', () => {
+  it('extracts the lowercase extension used for file-type icons', () => {
+    expect(fileExtension('src/ui/App.TSX')).toBe('tsx')
+    expect(fileExtension('manifest.test.ts')).toBe('ts')
+    expect(fileExtension('C:\\repo\\styles.css')).toBe('css')
+  })
+
+  it('returns nothing for dotfiles, extensionless names, and odd suffixes', () => {
+    expect(fileExtension('.gitignore')).toBeUndefined()
+    expect(fileExtension('Makefile')).toBeUndefined()
+    expect(fileExtension('src/dir.with.dot/')).toBeUndefined()
+    expect(fileExtension('archive.tar.gz')).toBe('gz')
   })
 })

--- a/test/workspace-file-ranker.test.ts
+++ b/test/workspace-file-ranker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { WorkspaceFileView } from '../src/editor/types.js'
-import { rankWorkspaceFiles } from '../src/editor/workspace-file-ranker.js'
+import { matchBareFileName, rankWorkspaceFiles } from '../src/editor/workspace-file-ranker.js'
 
 const files: readonly WorkspaceFileView[] = [
   { id: '1', path: 'src/ui/workbench-view-provider.ts', label: 'workbench-view-provider.ts' },
@@ -18,5 +18,24 @@ describe('rankWorkspaceFiles', () => {
 
   it('returns a bounded deterministic list for an empty @ query', () => {
     expect(rankWorkspaceFiles(files, '', 2).map((file) => file.id)).toEqual(['4', '1'])
+  })
+})
+
+describe('matchBareFileName', () => {
+  it('matches indexed basenames exactly, shortest path first', () => {
+    const duplicates: readonly WorkspaceFileView[] = [
+      { id: '5', path: 'src/deep/package.json', label: 'package.json' },
+      { id: '6', path: 'package.json', label: 'package.json' },
+      { id: '7', path: 'docs/package.json', label: 'package.json' },
+    ]
+
+    expect(matchBareFileName(duplicates, 'package.json').map((file) => file.id)).toEqual(['6', '7', '5'])
+  })
+
+  it('ignores directory-qualified or non-matching names', () => {
+    expect(matchBareFileName(files, 'ui/workbench-view-provider.ts')).toEqual([])
+    expect(matchBareFileName(files, 'C:\\repo\\package.json')).toEqual([])
+    expect(matchBareFileName(files, 'PACKAGE.JSON')).toEqual([])
+    expect(matchBareFileName(files, '')).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- `.md-file-link` now carries a `data-file-ext` badge styled per file type (TS-blue squares, ⚛ for tsx, etc.), matching the Cursor-style link chips — no icon font or image assets
- bare file names from model prose (e.g. `manifest.test.ts` living at `test/manifest.test.ts`) previously failed to open; `WorkspaceFileService.open` now falls back to an exact, deterministically-ordered basename match against the workspace file index

## Test plan
- `npm run check-types`, `npm test` (131 passed; new `fileExtension` and `matchBareFileName` cases)
- manual: assistant conclusion mentioning `foo.ts` / `src/bar.ts:12` renders icon + link, click opens the file at the line