### PR TITLE
chore: drop the vision router from the built-in plugins

### DIFF
--- a/src/plugins/default-plugins.ts
+++ b/src/plugins/default-plugins.ts
@@ -16,23 +16,6 @@ export interface DefaultBuiltinPlugin {
 
 export const DEFAULT_BUILTIN_PLUGINS: readonly DefaultBuiltinPlugin[] = [
   {
-    id: 'https://github.com/ysr666/dsh-vision-router',
-    name: 'DSH Vision Router',
-    owner: 'ysr666',
-    description: {
-      en: 'Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) plus pixel-level vision tools for Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, and screenshots.',
-      zh: '为纯文本 DeepSeek Harness Agent 提供视觉能力：内置免费视觉链路（无需密钥）加像素级视觉工具，支持问答、定位、裁剪、像素对比、取色、OCR、SVG 矢量化、抠图与截图。',
-    },
-    category: 'vision',
-    categoryLabel: { en: 'Vision', zh: '视觉' },
-    repositoryUrl: 'https://github.com/ysr666/dsh-vision-router',
-    installSpec: 'dsh-vision-router',
-    installedName: 'dsh-vision-router',
-    npmPackage: 'dsh-vision-router',
-    updatedAt: '2026-08-14T00:00:00Z',
-    compatibility: 'agent',
-  },
-  {
     id: 'https://github.com/yjh051108/dsh-super-injector',
     name: 'DSH Super Injector',
     owner: 'yjh051108',

--- a/test/plugin-catalog.test.ts
+++ b/test/plugin-catalog.test.ts
@@ -104,7 +104,6 @@ describe('DSH plugin catalog sources', () => {
     expect(contribution.source).toBe('builtin')
     expect(contribution.categories).toEqual([
       { id: 'routing', label: '路由与工作流' },
-      { id: 'vision', label: '视觉' },
       { id: 'import', label: '导入' },
     ])
     expect(contribution.plugins[0]).toMatchObject({
@@ -117,27 +116,17 @@ describe('DSH plugin catalog sources', () => {
     })
     expect(contribution.plugins.map((plugin) => plugin.name)).toEqual([
       'DSH Routing Suite',
-      'DSH Vision Router',
       'DSH Super Injector',
       'DSH Chat Import',
     ])
     expect(contribution.plugins[1]).toMatchObject({
-      name: 'DSH Vision Router',
-      installSpec: 'dsh-vision-router',
-      npmPackage: 'dsh-vision-router',
-      installedName: 'dsh-vision-router',
-      installKind: 'package',
-      catalogSource: 'builtin',
-      compatibility: 'agent',
-    })
-    expect(contribution.plugins[2]).toMatchObject({
       name: 'DSH Super Injector',
       installedName: '@dsh-external/dsh-super-injector',
       installKind: 'package',
       catalogSource: 'builtin',
       compatibility: 'agent',
     })
-    expect(contribution.plugins[3]).toMatchObject({
+    expect(contribution.plugins[2]).toMatchObject({
       name: 'DSH Chat Import',
       installSpec: 'dsh-chat-import',
       installedName: 'dsh-chat-import',
@@ -188,9 +177,8 @@ describe('DSH plugin catalog sources', () => {
     const service = new DshPluginCatalogService(workingSource, failingSource)
 
     const catalog = await service.load('en')
-    expect(catalog.plugins).toHaveLength(6)
+    expect(catalog.plugins).toHaveLength(5)
     expect(catalog.plugins.some((plugin) => plugin.name === 'DSH Routing Suite')).toBe(true)
-    expect(catalog.plugins.some((plugin) => plugin.name === 'DSH Vision Router')).toBe(true)
     expect(catalog.plugins.some((plugin) => plugin.name === 'DSH Super Injector')).toBe(true)
     expect(catalog.plugins.some((plugin) => plugin.name === 'DSH Chat Import')).toBe(true)
     expect(catalog.topicRepositoryCount).toBe(3016)


### PR DESCRIPTION
## Summary
- remove DSH Vision Router from `DEFAULT_BUILTIN_PLUGINS`: it disappears from the built-in catalog and is never auto-installed on first run or seed bumps going forward
- the remaining built-ins (Routing Suite, Super Injector, Chat Import) are unchanged; already-seeded installs keep their seed marker, so nothing is reinstalled

## Test plan
- `npm run check-types`, `npm test` (137 passed; catalog assertions updated for the removed entry)