### PR TITLE
feat: spread provider tabs beside the model list

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -667,15 +667,18 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .configuration-group:not(.collapsed) .configuration-group-current { display: none; }
 .configuration-options { display: grid; gap: 2px; }
 .configuration-model-group .configuration-options { grid-template-columns: 1fr; gap: 4px; }
-/* Second-level provider accordion inside the Models group (only rendered
-   when more than one provider is configured). */
-.configuration-provider-group { display: grid; gap: 4px; }
-.configuration-provider-toggle {
+/* Master-detail provider layout inside the Models group (only rendered when
+   more than one provider is configured): provider tabs on the left rail,
+   the open provider's models in the right column. */
+.configuration-provider-layout { display: grid; grid-template-columns: minmax(0, 44%) minmax(0, 1fr); gap: 6px; align-items: start; }
+.configuration-provider-rail { display: grid; gap: 3px; align-content: start; }
+.configuration-provider-tab {
   width: 100%;
-  padding: 4px 6px;
+  min-width: 0;
+  padding: 6px;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   color: color-mix(in srgb, var(--vscode-foreground) 82%, transparent);
   background: color-mix(in srgb, var(--vscode-editor-background) 88%, transparent);
   border: 1px solid var(--vscode-widget-border);
@@ -685,13 +688,13 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
   text-align: left;
   cursor: pointer;
 }
-.configuration-provider-toggle:hover { color: var(--vscode-foreground); background: var(--vscode-list-hoverBackground); }
-.configuration-provider-toggle:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
-.configuration-provider-chevron { flex: none; transition: transform 140ms ease; }
-.configuration-provider-group:not(.collapsed) .configuration-provider-chevron { transform: rotate(90deg); }
-.configuration-provider-current { min-width: 0; margin-left: auto; overflow: hidden; color: color-mix(in srgb, var(--vscode-foreground) 68%, transparent); font-weight: 400; text-overflow: ellipsis; white-space: nowrap; }
-.configuration-provider-group.collapsed .configuration-provider-models { display: none; }
-.configuration-provider-models { display: grid; gap: 4px; }
+.configuration-provider-tab:hover { color: var(--vscode-foreground); background: var(--vscode-list-hoverBackground); }
+.configuration-provider-tab:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+.configuration-provider-tab.active { color: var(--vscode-foreground); background: color-mix(in srgb, var(--vscode-list-activeSelectionBackground) 55%, transparent); border-color: color-mix(in srgb, var(--vscode-focusBorder) 45%, transparent); }
+.configuration-provider-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.configuration-provider-current { min-width: 0; overflow: hidden; color: color-mix(in srgb, var(--vscode-foreground) 68%, transparent); font-size: 10px; font-weight: 400; text-overflow: ellipsis; white-space: nowrap; }
+.configuration-provider-chevron { flex: none; margin-left: auto; color: var(--vscode-descriptionForeground); }
+.configuration-provider-models { display: grid; gap: 4px; align-content: start; }
 .configuration-option {
   width: 100%;
   min-width: 0;

--- a/src/webview/composer-configuration/component.ts
+++ b/src/webview/composer-configuration/component.ts
@@ -36,7 +36,7 @@ export function createComposerConfigurationComponent(options: ComponentOptions):
 class ComposerConfigurationDom implements ComposerConfigurationComponent {
   private readonly store = new ComposerConfigurationStore()
   private effortDragging = false
-  /** '' collapses every provider; undefined follows the current selection. */
+  /** Provider tab shown in the model rail; defaults to the selection's. */
   private expandedProvider: string | undefined
   private readonly panel: HTMLElement
   private readonly toggle: HTMLButtonElement
@@ -292,54 +292,59 @@ class ComposerConfigurationDom implements ComposerConfigurationComponent {
         for (const model of models) fragment.append(this.modelButton(snapshot, model))
       }
     } else {
-      // Multiple providers get their own collapsible level between the Models
-      // group and the model list, accordion-style (one open at a time).
+      // Multiple providers get a master-detail layout: provider tabs on the
+      // left rail, the open provider's models in a column on the right.
       const openProvider = this.expandedProvider ?? snapshot.selection.provider
+      const layout = this.options.document.createElement('div')
+      layout.className = 'configuration-provider-layout'
+      const rail = this.options.document.createElement('div')
+      rail.className = 'configuration-provider-rail'
+      const detail = this.options.document.createElement('div')
+      detail.className = 'configuration-provider-models'
       for (const [provider, models] of groups) {
-        fragment.append(this.providerGroup(snapshot, provider, models, provider === openProvider))
+        rail.append(this.providerTab(snapshot, provider, models, provider === openProvider))
+        if (provider === openProvider) {
+          for (const model of models) detail.append(this.modelButton(snapshot, model))
+        }
       }
+      layout.append(rail, detail)
+      fragment.append(layout)
     }
     this.models.replaceChildren(fragment)
   }
 
-  private providerGroup(
+  private providerTab(
     snapshot: ComposerConfigurationSnapshot,
     provider: string,
     models: readonly ModelConfigurationOption[],
-    expanded: boolean,
-  ): HTMLElement {
-    const document = this.options.document
-    const group = document.createElement('div')
-    group.className = `configuration-provider-group${expanded ? '' : ' collapsed'}`
-    const toggle = document.createElement('button')
-    toggle.type = 'button'
-    toggle.className = 'configuration-provider-toggle'
-    toggle.setAttribute('aria-expanded', String(expanded))
-    const chevron = document.createElement('span')
+    open: boolean,
+  ): HTMLButtonElement {
+    const tab = this.options.document.createElement('button')
+    tab.type = 'button'
+    tab.className = `configuration-provider-tab${open ? ' active' : ''}`
+    tab.setAttribute('aria-pressed', String(open))
+    const name = this.options.document.createElement('span')
+    name.className = 'configuration-provider-name'
+    name.textContent = models[0]?.providerName ?? provider
+    tab.append(name)
+    const selected = models.find((model) => model.provider === snapshot.selection.provider && model.id === snapshot.selection.model)
+    if (selected !== undefined && !open) {
+      const current = this.options.document.createElement('span')
+      current.className = 'configuration-provider-current'
+      current.textContent = selected.label
+      tab.append(current)
+    }
+    const chevron = this.options.document.createElement('span')
     chevron.className = 'configuration-provider-chevron'
     chevron.setAttribute('aria-hidden', 'true')
     chevron.textContent = '›'
-    const name = document.createElement('span')
-    name.textContent = models[0]?.providerName ?? provider
-    toggle.append(chevron, name)
-    const selected = models.find((model) => model.provider === snapshot.selection.provider && model.id === snapshot.selection.model)
-    if (selected !== undefined) {
-      const current = document.createElement('span')
-      current.className = 'configuration-provider-current'
-      current.textContent = selected.label
-      toggle.append(current)
-    }
-    toggle.addEventListener('click', () => {
-      // '' means every provider is collapsed; undefined falls back to the
-      // provider holding the current selection.
-      this.expandedProvider = expanded ? '' : provider
+    tab.append(chevron)
+    tab.addEventListener('click', () => {
+      if (open) return
+      this.expandedProvider = provider
       this.render(this.store.snapshot())
     })
-    const list = document.createElement('div')
-    list.className = 'configuration-provider-models'
-    for (const model of models) list.append(this.modelButton(snapshot, model))
-    group.append(toggle, list)
-    return group
+    return tab
   }
 
   private modelButton(snapshot: ComposerConfigurationSnapshot, model: ModelConfigurationOption): HTMLButtonElement {


### PR DESCRIPTION
## Summary
- multi-provider model picking now reads as master-detail: provider tabs sit on a left rail and the open provider's models fill the column on the right, instead of expanding the list downward
- the tab holding the current selection opens by default and shows the selected model when another tab is open; a single provider still lists its models directly

## Test plan
- `npm run check-types`, `npm test` (137 passed)
- visual: headless-Chrome render of the two-pane layout against the real stylesheet