### PR TITLE
style: flatten the model picker and let the panel size itself

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -639,7 +639,6 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
   bottom: calc(100% + 8px);
   z-index: 24;
   width: min(340px, calc(100% - 12px));
-  max-height: min(78vh, 560px);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
@@ -655,7 +654,8 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 #configuration-source { min-width: 0; max-width: 112px; height: 24px; padding: 0 20px 0 6px; overflow: hidden; color: var(--vscode-dropdown-foreground); background: var(--vscode-dropdown-background); border: 1px solid var(--vscode-dropdown-border, var(--vscode-widget-border)); border-radius: 6px; text-overflow: ellipsis; font: inherit; font-size: 11px; }
 #configuration-source:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; }
 #configuration-source:disabled { opacity: .65; }
-.configuration-panel-scroll { min-height: 0; padding: 0 8px 8px; display: grid; gap: 7px; overflow-y: auto; overscroll-behavior: contain; }
+/* The panel sizes to its content; groups never make the user scroll. */
+.configuration-panel-scroll { min-height: 0; padding: 0 8px 8px; display: grid; gap: 7px; overflow-y: visible; overscroll-behavior: contain; }
 .configuration-group { display: grid; gap: 4px; }
 .configuration-group h3 { margin: 0; }
 .configuration-group-toggle { width: 100%; padding: 2px 5px; display: flex; align-items: center; gap: 5px; color: color-mix(in srgb, var(--vscode-foreground) 88%, transparent); background: transparent; border: 0; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; text-align: left; cursor: pointer; }
@@ -675,22 +675,22 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 .configuration-provider-tab {
   width: 100%;
   min-width: 0;
-  padding: 6px;
+  padding: 7px 9px;
   display: flex;
   align-items: center;
   gap: 4px;
   color: color-mix(in srgb, var(--vscode-foreground) 82%, transparent);
-  background: color-mix(in srgb, var(--vscode-editor-background) 88%, transparent);
-  border: 1px solid var(--vscode-widget-border);
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 8px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
 }
 .configuration-provider-tab:hover { color: var(--vscode-foreground); background: var(--vscode-list-hoverBackground); }
 .configuration-provider-tab:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
-.configuration-provider-tab.active { color: var(--vscode-foreground); background: color-mix(in srgb, var(--vscode-list-activeSelectionBackground) 55%, transparent); border-color: color-mix(in srgb, var(--vscode-focusBorder) 45%, transparent); }
+.configuration-provider-tab.active { color: var(--vscode-foreground); background: var(--vscode-list-hoverBackground); border-color: transparent; }
 .configuration-provider-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .configuration-provider-current { min-width: 0; overflow: hidden; color: color-mix(in srgb, var(--vscode-foreground) 68%, transparent); font-size: 10px; font-weight: 400; text-overflow: ellipsis; white-space: nowrap; }
 .configuration-provider-chevron { flex: none; margin-left: auto; color: var(--vscode-descriptionForeground); }
@@ -709,9 +709,14 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
   border-radius: 10px;
   text-align: left;
 }
-.configuration-model-group .configuration-option { min-height: 38px; padding: 6px; grid-template-columns: 20px minmax(0, 1fr) 13px; gap: 4px; background: color-mix(in srgb, var(--vscode-editor-background) 88%, transparent); border-color: var(--vscode-widget-border); }
+/* Codex-style flat model rows: no card chrome, the check mark carries the
+   selection and hover gets the rounded wash. */
+.configuration-model-group .configuration-option { min-height: 0; padding: 7px 9px; grid-template-columns: minmax(0, 1fr) 13px; gap: 4px; background: transparent; border-color: transparent; border-radius: 8px; }
+.configuration-model-group .configuration-option-icon { display: none; }
+.configuration-model-group .configuration-option.active { color: var(--vscode-foreground); background: transparent; border-color: transparent; }
+.configuration-model-group .configuration-option.active .configuration-option-check { color: var(--vscode-foreground); }
 .configuration-model-group .configuration-option-copy small { display: none; }
-.configuration-model-group .configuration-option-copy strong { overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: anywhere; line-height: 1.15; }
+.configuration-model-group .configuration-option-copy strong { line-height: 1.3; }
 .configuration-option:hover { background: var(--vscode-list-hoverBackground); }
 .configuration-option:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
 .configuration-option.active { color: var(--vscode-list-activeSelectionForeground); background: color-mix(in srgb, var(--vscode-list-activeSelectionBackground) 78%, transparent); border-color: color-mix(in srgb, var(--vscode-focusBorder) 45%, transparent); }
@@ -1278,7 +1283,6 @@ body.vscode-dark .empty-logo, body.vscode-high-contrast .empty-logo { filter: in
 }
 
 @media (max-width: 320px) {
-  .configuration-panel { max-height: min(84vh, 620px); }
   .configuration-model-group .configuration-options { grid-template-columns: minmax(0, 1fr); }
   .effort-main { display: grid; gap: 3px; }
   .effort-heading { min-width: 0; padding-top: 0; }


### PR DESCRIPTION
## Summary
- model rows drop the card chrome for Codex-style flat rows: the check mark carries the selection, hover gets the rounded wash, row icons go
- provider tabs follow the same flat treatment
- the configuration panel sizes to its content and the inner scroll area is gone, so expanded groups never show a scrollbar

## Test plan
- `npm run check-types`, `npm test` (137 passed)
- visual: headless-Chrome render of the flat list against the real stylesheet — plain rows, check on the active row, hover wash, single-line labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the configuration panel layout by removing unnecessary height restrictions and internal scrolling.
  * Simplified provider tabs with flatter styling, lighter appearance, and more compact spacing.
  * Streamlined model options into clean, borderless rows with simpler active-state highlighting.
  * Improved the configuration panel experience on narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->