### PR TITLE
fix: prune stale profile runtime packages before the gateway boots

### DIFF
--- a/src/runtime/profile-scope-prune.ts
+++ b/src/runtime/profile-scope-prune.ts
@@ -1,0 +1,57 @@
+import { readdir, readFile, rm } from 'node:fs/promises'
+import * as path from 'node:path'
+
+/**
+ * Removes profile-level copies of @deepseek-ai runtime packages whose version
+ * differs from the runtime bundled in the VSIX.
+ *
+ * cordis-plugin-loader resolves profile entries from the profile's own
+ * node_modules before the CLI bundle, so a package planted there by an older
+ * extension build (e.g. dsh-llm-deepseek@0.1.0-rc.6, whose config schema
+ * pre-dates the `low` reasoning tier) shadows the bundled runtime and crashes
+ * the Gateway boot with a stale-schema validation error. Pruning mismatched
+ * copies makes resolution fall through to the bundled packages again.
+ *
+ * Returns the names of the removed packages. Unreadable entries are left in
+ * place: pruning must never block the boot.
+ */
+export async function pruneShadowedRuntimePackages(
+  profileScopeDir: string,
+  bundledScopeDir: string,
+  log: (line: string) => void,
+): Promise<string[]> {
+  const removed: string[] = []
+  let names: string[]
+  try {
+    names = (await readdir(profileScopeDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .map((entry) => entry.name)
+  } catch {
+    return removed
+  }
+  for (const name of names) {
+    const bundledVersion = await packageVersion(path.join(bundledScopeDir, name))
+    if (bundledVersion === undefined) continue
+    const profileVersion = await packageVersion(path.join(profileScopeDir, name))
+    if (profileVersion === undefined || profileVersion === bundledVersion) continue
+    try {
+      await rm(path.join(profileScopeDir, name), { recursive: true, force: true })
+      removed.push(name)
+      log(`[host] Pruned stale profile runtime package @deepseek-ai/${name}@${profileVersion} (bundled: ${bundledVersion}).`)
+    } catch {
+      log(`[host] Failed to prune stale profile runtime package @deepseek-ai/${name}@${profileVersion}.`)
+    }
+  }
+  return removed
+}
+
+async function packageVersion(directory: string): Promise<string | undefined> {
+  try {
+    const manifest = JSON.parse(await readFile(path.join(directory, 'package.json'), 'utf8')) as unknown
+    if (typeof manifest !== 'object' || manifest === null) return undefined
+    const version = (manifest as Record<string, unknown>).version
+    return typeof version === 'string' ? version : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/runtime/web-runtime.ts
+++ b/src/runtime/web-runtime.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path'
 import * as vscode from 'vscode'
 import type { ConfigurationService, HarnessConfiguration } from '../config/configuration.js'
 import type { BundledRuntimeResolver } from './bundled-runtime.js'
+import { pruneShadowedRuntimePackages } from './profile-scope-prune.js'
 import { renderOverlay } from './runtime-overlay.js'
 
 const START_TIMEOUT_MS = 90_000
@@ -91,6 +92,14 @@ export class HarnessHostRuntime implements vscode.Disposable {
     const gatewayPlugin = path.join(this.context.extensionUri.fsPath, 'dist', 'runtime', 'gateway-runtime.mjs')
     await mkdir(home, { recursive: true })
     await writeFile(overlay, renderOverlay(configuration, gatewayPlugin), 'utf8')
+    // Profile-level @deepseek-ai copies shadow the bundled runtime during
+    // plugin resolution; drop stale ones so an older build's leftovers cannot
+    // fail the boot with a stale-schema validation error.
+    await pruneShadowedRuntimePackages(
+      path.join(home, 'profiles', 'web', 'node_modules', '@deepseek-ai'),
+      this.context.asAbsolutePath(path.join('node_modules', '@deepseek-ai')),
+      (line) => this.output.appendLine(line),
+    )
 
     const args = [...launch.args, 'web', '--patch', overlay, '--host', '127.0.0.1', '--port', '0']
     const env: NodeJS.ProcessEnv = {

--- a/test/profile-scope-prune.test.ts
+++ b/test/profile-scope-prune.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { pruneShadowedRuntimePackages } from '../src/runtime/profile-scope-prune.js'
+
+let root = ''
+
+async function setup(): Promise<{ profileScope: string, bundledScope: string }> {
+  root = await mkdtemp(path.join(tmpdir(), 'profile-scope-prune-'))
+  const profileScope = path.join(root, 'profile', 'node_modules', '@deepseek-ai')
+  const bundledScope = path.join(root, 'bundled', 'node_modules', '@deepseek-ai')
+  await mkdir(profileScope, { recursive: true })
+  await mkdir(bundledScope, { recursive: true })
+  return { profileScope, bundledScope }
+}
+
+async function plantPackage(scope: string, name: string, version: string): Promise<void> {
+  const directory = path.join(scope, name)
+  await mkdir(directory, { recursive: true })
+  await writeFile(path.join(directory, 'package.json'), JSON.stringify({ name, version }))
+}
+
+afterEach(async () => {
+  if (root !== '') await rm(root, { recursive: true, force: true })
+  root = ''
+})
+
+describe('pruneShadowedRuntimePackages', () => {
+  it('removes profile copies whose version differs from the bundled runtime', async () => {
+    const { profileScope, bundledScope } = await setup()
+    await plantPackage(profileScope, 'dsh-llm-deepseek', '0.1.0-rc.6')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    const lines: string[] = []
+
+    const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, (line) => lines.push(line))
+
+    expect(removed).toEqual(['dsh-llm-deepseek'])
+    expect(lines[0]).toContain('0.1.0-rc.6')
+    await expect(readVersion(profileScope, 'dsh-llm-deepseek')).resolves.toBeUndefined()
+  })
+
+  it('keeps profile copies that match the bundled version or have no bundled counterpart', async () => {
+    const { profileScope, bundledScope } = await setup()
+    await plantPackage(profileScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    await plantPackage(profileScope, 'dsh-profile-only-plugin', '9.9.9')
+
+    const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, () => {})
+
+    expect(removed).toEqual([])
+    await expect(readVersion(profileScope, 'dsh-llm-deepseek')).resolves.toBe('0.1.1-rc.1')
+    await expect(readVersion(profileScope, 'dsh-profile-only-plugin')).resolves.toBe('9.9.9')
+  })
+
+  it('ignores a missing or unreadable profile scope directory', async () => {
+    const { bundledScope } = await setup()
+    const missing = path.join(root, 'nope', '@deepseek-ai')
+    await expect(pruneShadowedRuntimePackages(missing, bundledScope, () => {})).resolves.toEqual([])
+  })
+
+  it('keeps profile copies whose manifest cannot be read', async () => {
+    const { profileScope, bundledScope } = await setup()
+    const broken = path.join(profileScope, 'dsh-llm-deepseek')
+    await mkdir(broken, { recursive: true })
+    await writeFile(path.join(broken, 'package.json'), 'not json')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+
+    const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, () => {})
+
+    expect(removed).toEqual([])
+  })
+})
+
+async function readVersion(scope: string, name: string): Promise<string | undefined> {
+  try {
+    const manifest = JSON.parse(await readFile(path.join(scope, name, 'package.json'), 'utf8')) as { version?: string }
+    return manifest.version
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the 0.5.0 boot crash reported on Windows: `dsh: plugin tree failed to load ... llm-deepseek: invalid config: $.reasoningEffort expected "off" | "high" | "max" but got "low"`.

Root cause, reproduced locally: cordis-plugin-loader resolves profile entries from the profile's own `node_modules` before the CLI bundle, so a `@deepseek-ai/dsh-llm-deepseek@0.1.0-rc.6` copy left behind by an older extension build (rc.6's config schema pre-dates the `low` tier) shadows the VSIX-bundled runtime and rejects the overlay the extension writes.

- on startup, each profile-level `@deepseek-ai/*` copy is compared against the bundled runtime version and pruned on mismatch, so resolution falls through to the VSIX packages
- pruning is logged, tolerant of unreadable entries, and never blocks the boot
- verified end-to-end: a stale rc.6 copy planted in a scratch DSH_HOME reproduces the exact crash; after pruning, the same home boots cleanly with `reasoningEffort: low`

## Test plan
- `npm run check-types`, `npm test` (141 passed; new profile-scope-prune suite)
- manual: users hitting the crash just reload the window — the next boot self-heals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removes outdated profile runtime packages before launching the bundled Gateway.
  * Preserves compatible, profile-only, or unreadable packages to avoid disrupting startup.
  * Reports cleanup successes and failures without blocking application launch.

* **Tests**
  * Added coverage for package version mismatches, missing directories, matching versions, and unreadable manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->