### PR TITLE
chore: bump the bundled dsh runtime to 0.1.1-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A native VS Code coding-agent extension powered by [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). Install the platform-specific VSIX and start working—there is no upstream repository to clone, no Node/npm setup, and no local Harness deployment to manage.
 
-> This is a community-maintained `0.4.8` release. DeepSeek Harness is currently a Developer Preview, and this extension pins the official `@deepseek-ai/dsh@0.1.1-rc.1` package.
+> This is a community-maintained `0.4.8` release. DeepSeek Harness is currently a Developer Preview, and this extension pins the official `@deepseek-ai/dsh@0.1.1-rc.2` package.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 在 VS Code 中原生运行 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的 AI 编码助手扩展。无需克隆上游仓库、安装 Node/npm 或手动部署 Harness；安装匹配平台的 VSIX 即可使用。
 
-> 当前为社区开发版本 `0.4.8`。DeepSeek Harness 仍处于 Developer Preview，本扩展固定使用官方 npm 包 `@deepseek-ai/dsh@0.1.1-rc.1`。
+> 当前为社区开发版本 `0.4.8`。DeepSeek Harness 仍处于 Developer Preview，本扩展固定使用官方 npm 包 `@deepseek-ai/dsh@0.1.1-rc.2`。
 
 ## 功能
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 This platform extension bundle contains:
 
-- `@deepseek-ai/dsh` 0.1.1-rc.1 and its `@deepseek-ai/dsh-*` dependencies
+- `@deepseek-ai/dsh` 0.1.1-rc.2 and its `@deepseek-ai/dsh-*` dependencies
   - Copyright: DeepSeek contributors
   - License: MIT
   - Source: https://github.com/deepseek-ai/deepseek-harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "deepseek-harness-for-vscode",
-  "version": "0.4.9",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepseek-harness-for-vscode",
-      "version": "0.4.9",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh": "^0.1.1-rc.2",
         "dompurify": "3.4.13",
         "markdown-it": "15.0.0",
         "node": "22.22.3",
@@ -818,9 +818,9 @@
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh/-/dsh-0.1.1-rc.1.tgz",
-      "integrity": "sha512-HVauMT0F7MWUctkxzBcu5PMFc8j0lm0kX+4IbcUsA7Oh+/xv7xhigEDP0SaSOM/kR48U/BldHbZru116DcZz0w==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh/-/dsh-0.1.1-rc.2.tgz",
+      "integrity": "sha512-UP1UIh6q3Gme/yXRn/QL2P8IsVlv8Shpg22TRJIZPsCRWLm4CBiA1MUvXmJAfsOEETBMLAl+xWPtFw6ICsN3wg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
@@ -828,60 +828,60 @@
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-base": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-headless": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-persona": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-base": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-headless": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-persona": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-schedule": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-time-context": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web-app": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2",
         "commander": "^15.0.0",
         "js-yaml": "^4.2.0",
         "node-addon-require-builtin": "^0.1.4"
@@ -891,80 +891,80 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-xE+oni6Ig32Q7QspcUVQqGOa9QYiWwwaqG8ci43+oc2vfslXbD9RJ+qnk9XFKidnVn6cwB95Aw4eeivy0ufDCg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.1.tgz",
-      "integrity": "sha512-PZl4y+vW3nhaYljebQ0mZELKvfw61neybWeuMYBdprrM0TnjbYStY0drxynowxqaGoBPUO5Ty3q9Px4hbUYaLw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.1.tgz",
-      "integrity": "sha512-/BZNgV2qnwERp4EpH0Lu/U6RWUDEu+u7W0Xu9y3/b0PvGsBz5oeucPnaFOKEXIIHDVnuFvo2513sYOsaoj0xWA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.1-rc.2.tgz",
+      "integrity": "sha512-a3xKsOsqmlWZaGxXfIr97ULJlXSI1clZt0DCSjCaULW4Z1y67DzG8w/kRsb+/Z1pksRMrJE7faLMC/i9S5Y2Ew==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-loop": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.1.tgz",
-      "integrity": "sha512-Cu/z/oT5DPV6jDU9+X1Hbi0ex4OPHMF7eK9+sMOjvgJSlXJWU2Htg7/XfFEOLMkrerA48CopieWrbNLSL1pFGg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.1-rc.2.tgz",
+      "integrity": "sha512-2uJZ6kjJ3IYLRGn6/NhiZgD576ABcbERB/nkReR9TEUMO2zWkz6OuKtVwLyFCFSni2T25Jv+clKQWt7D4MhU3A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.1.tgz",
-      "integrity": "sha512-m+IitPjH4knw1fWzIv/6AqkLj6vRH956oop0okNAa5tkbyz9B4XwR7I81+2ifqc7btp2e5TIBl8lgx4WyxUbhg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.2.tgz",
+      "integrity": "sha512-88r3jkrbdwTgcP3MZLIUX458Ecu8JcLmZa7PtPszwf33yFoWlZvZmgjyn5ETHV55plNQ8gKMRm9a0RwzGGmzCw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -974,91 +974,91 @@
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.1.tgz",
-      "integrity": "sha512-XH7Fik0+ktVGzx4FEvFKDDYJNYU/AhQfcyPi/BNhIegBPCXAdLTbomwh3bb5FBhMiYcwq1bPQknxS8kN+tmuFA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.1-rc.2.tgz",
+      "integrity": "sha512-l1C7Z+erWcfj6Ak5EQbcCAPW/0+na4iOXwGknozHgKILLCK2C9CWcrTK0LwozvUPdqh0gFUucSOhi68HQ61srg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.1.tgz",
-      "integrity": "sha512-SBXf0wg4HO9PDTb+GFJuSQ8OzARDojF0UhoveD/j1roF6X6pnRjkDsRaYUWg3Uwmim3Bc5Dckutgu9p14hFn1Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ZQBsDhI0VuFwoDnq75VT2gPJdMPmBYfWM3EBDmUkwHM0E2dmyr+iLGXxp33a7M64r79x7kN+81KOTEL5LS0E8A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.1.tgz",
-      "integrity": "sha512-+fi1Zo1bY1dB+Qr5Q+iLxr1kSL9sigWhdMiK0tV9dAPY4BxOunwjiTh614P6jsRTvDAh/VDaHEQsHcv1T4YY9Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.2.tgz",
+      "integrity": "sha512-i/e/Ecg1QCjMePUFHBfjRQU3NbDV0IdORwQbQD6RpiirzyvAIm4vvZgmW/FfgkO2XYJHHIVjo3i1i0YaHPcQag==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TOeb0DsrjUyZIlL/Ih1loEg2UelVQdLX9Vck6LgCjZcH7UJvQdYuMKt5G8Tbvms3ZHvlpvCc7kue4sQlZ9rKDA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.2.tgz",
+      "integrity": "sha512-mtmMxA0TZwTjy46E2DF0kmsPCXVq6RBhrwEHWXBaRzc0DLjnYqmJODrZ0X+XwXOkwFZtDxWSv/uheiIsXf8now==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-app-boot": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.1.tgz",
-      "integrity": "sha512-gef6HqCpdf/aLXH8G4TZ+fIxtq+ebiKDrtr2pslFiopWWrxEvqhZdNPgpiC9A8IDfX3waOxcNxhvmlPHpV2moQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.1-rc.2.tgz",
+      "integrity": "sha512-eynZWb0oNPKc4OO3HPokqFfz4b5sUEq+EjqhKE2TUWsUsOTgFO43l2Ai3LibqLu6XTpYeHCTbsRLM4Aqg0deBQ==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0"
@@ -1069,10 +1069,10 @@
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-include": "^1.0.6",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-hmr": {
@@ -1081,31 +1081,31 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.1.tgz",
-      "integrity": "sha512-8cSMtRK2+5OcyvRhyJRI6lVVuIp+r7MBKGlfESOIdK50OWnVUM35IvaWXuwQrMOI/xJDihyDF+KGF1o0aM1vhg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.2.tgz",
+      "integrity": "sha512-QqNSF0+Ddn6qWY480dlilwEy6FLv3JKEWx1UQgoNJrxD4y54SDRzqBQB9yDXWKOoOGyC+05TN6/Px10GNIzMWA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.1.tgz",
-      "integrity": "sha512-R5xKO2z+91Ze25E+ghk3qDJf7ZA4t2sqMF1wusp2/6KrF0UzhCpGt/SWtdjRXSwz6DTjsAfZzpPC5D+2EmuHxA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.2.tgz",
+      "integrity": "sha512-rCYAt8QsawP1yfDCU7XxNwYT/XWvyFsxYrkwhLLkdfW83QVD0CQHizSkTQE7RFX74nKUD1z3sTLfnLr7xneArw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-KGJVu0q3yPlcfoPg+4FGTI1O8sS08B/POQ4jLQvKG7sjx3kXXx/S8xD5BTeFuYijM3mSCCC96AI4lha28v+04Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-bU24CZc2ElJ7JPUUeWLcibRsiuXjsj9dVuUu8yx6t2vensjbqo70kzAIA4eh9q6ai4CeU1/9cRnKLcMQbgNxMQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1113,117 +1113,117 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-authorization": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.1.tgz",
-      "integrity": "sha512-cf8LRUJJgpr88UVOPViQviKO+LJ92kdh465c4BvbO1HJDBHXME6fAgkDpDs+IbKdrdt3KWYqI/x2UK7tnFWqXg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.1-rc.2.tgz",
+      "integrity": "sha512-+ye7d4XzenQ4kpfY2nMIlUhoIbcprotL9fmkTBahafIPDhyyph0JzmUVhz1AGnkIqZc8TltjGzX2ssald+f+3A==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-base": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.1.tgz",
-      "integrity": "sha512-fJ4IlNFjAHj+5PTByTAs6fEj7GFirNmpL0eYA+KTwK5SGEupJ0COVCBOsDeNMUJZspsDKptkZm0szo2u09Q0MQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-base/-/dsh-base-0.1.1-rc.2.tgz",
+      "integrity": "sha512-DT1kSaseoTZ0b8pwZ5biRkqez2K8AnsLataRiCPsn3uUuxupZOjM1e8x9W+kpkWWFykWy1mbCPhzDRVJ+pLCbg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.16",
         "@deepseek-ai/cordis-plugin-timer": "^1.1.3",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-compact": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings-file": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-spill-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-subagent-report": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-web": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.1-rc.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-e0hgZMtQYPGSjB2gCJ6nTMlfKF+NXCE9IN6Z3TrpWMF9CQmqqqbyrUcY3+/JTVsoNoUk1aAMxMbXNFtGcYqEng==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-GAjYTVsJKXkAptjO767xqt0otMufZRtj2qvOAvkx5Bfusd5R6+mMUkSbcx2K2A8WMbltyCbjwhZf4Tu4xyJAdw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1231,41 +1231,41 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.1.tgz",
-      "integrity": "sha512-kH/rW2aXxlFoKpF+eLJcfO/WYvQxmqJYmmHzEZbJgbzbs6V6t1O2PMHnjIRvZXgzP4jXeb3a4+YwJzjfxVX13Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.1-rc.2.tgz",
+      "integrity": "sha512-bagZDMZ73C1dVDBjFCn1flNZ8aOEel4dsmDJTfmagqeYPXfIJDFKPhDc3lWjc+o6jMNfmumeUJ62dwhHkjJHKA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-bash-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.1.tgz",
-      "integrity": "sha512-u5+q1x5koviWTTaOiOUA0629ZNEKaRl2hu7iiGArzhvj+CUz7abh2b6IF3+xI4AMSHyvn+mOWN9Vwa2WVfwGLg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.2.tgz",
+      "integrity": "sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.1.tgz",
-      "integrity": "sha512-43j158P+X9hjJMZ76NsJsQTTDo7ws+aW5XMq3PmdJRVY6h15JsPrfALNosjaeiJjqxUXKSNOfHk7Oq8vJejsyw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YX2WLA/aZdDQsien4Zo7IHTEfYVJ+4QhRXbgA6BrRUM23NSP/+V3K00dQYyQVsF3ZwocE5uyvlZvbYeg1Iz4ug==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1273,20 +1273,20 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-hmr": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.1.tgz",
-      "integrity": "sha512-VQVrUtiBLB1FIvjlVBHx3OmK/TpR/nMoDqgxXFV9d0AAs3LdL20r9pSDcngpO0dhDI26LI9dcsgmVIp0MmV5AQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.1-rc.2.tgz",
+      "integrity": "sha512-q2YqCvIWXfVQBh+AWLQFDF2cMu2ZabgahGKrWXHqQ5q1dY0ae9CvDV+bCMf8+EwQgz1axSOXWQ35+SSKPGwGlw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -1294,45 +1294,45 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-locale": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.1.tgz",
-      "integrity": "sha512-siclYHjadMhc+Wh0wmV5twiu9oyBE719POQ1F2nM+H0mfScokHLqpBHkml8AJqIl0rkq3dxtkC19kUoBEJvNTQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.1-rc.2.tgz",
+      "integrity": "sha512-AMoR4FwMPLmt6WlYd4m0PCoxXj4qqMhpElBQZSc3r3NyGCZIuleU8tCG1xphGtr/w9mA1Y0kUX7Ftdmf7yV4FQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-modules": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.1.tgz",
-      "integrity": "sha512-cdBFlFE8sb+vD/w3gYKTu8LH+yH4OyPHXhxJTkzhQJF3bAhdC24k25mogaxkpZXg4rcHS16zWyCriZaOGQRgsQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.1-rc.2.tgz",
+      "integrity": "sha512-D0vRgJJpMeTB4ExJTGHk9ay01kLxfK5zvp6bgFjYGlk9sBJgCE3qsOGBFNqD369ylJx4W2oyExAH9lOZGNk3Rw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-runtime": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.1.tgz",
-      "integrity": "sha512-re0dq+vXlGIGMs5qQHJLMHael8FN+9zKTnGk2M0BQUH4fGr3jTOBUvoKUztbjW/DJP3l3f1k6uoDj2ri3DA0nA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.1-rc.2.tgz",
+      "integrity": "sha512-o1FH7Rlns0Xaxh4SBOWZ1wpa0ViGw6DXWNm5NFpsBTGYD94RGdIrud3QxgrfzmQKLzu33gvS8JL/IjqbzWyYsg==",
       "license": "MIT",
       "dependencies": {
         "immer": "^10.1.1",
@@ -1340,91 +1340,91 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.1.tgz",
-      "integrity": "sha512-z7u+1fFUURCQrpBXdqtcolPYpW1w6myFZBGMMgZeDpHP94p1CUsJ1KM/AP1FXJqnG4QmtbXaVQx6jR0LjAYdYA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.1-rc.2.tgz",
+      "integrity": "sha512-U8iT0+jQSbIdPPF4rYYEhmFaTyewryOgL/ye3322UhuFXFapjQcPTBkchvZYYWnTJ/SGB2CpKXLQqiVSjsN2tA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.1.tgz",
-      "integrity": "sha512-mOZQO7jozY/kX7m8jHm6h9VbXYMKPVAyhtJI0wPJXzL/DoqCvyN/SBaQ88Me+OM4bgn/Io3yj54r2wAoxdp7eA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.1-rc.2.tgz",
+      "integrity": "sha512-c3tLJL7Qhok4NzVTE/OomBAsNSLbryT0UndqLaxx/9hcS4W7A984SD0iOF9VuZT4dgZ6dQjMse9eIe9M7Kg08Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.1.tgz",
-      "integrity": "sha512-CuWaMd44IEpF9878yZdI13Vd/Ky8hlEag4KXWs5G3C01eAQTS2oM0FyIwohtNnIOPqo2LygHWKpSqKYfDYTvIg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ORrj3w92n5tif0ecKQy/xGd6vlHPkK3XZCxT0+7JUeA1GRo4TW/wc5ljm0/6hM4FcqKf2x7ndW+OdWfZ2Rwfdg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ht3Nd+kczdVK5/w50xp/qpTozwiHTCZW5/R9w7093DapF3mAYQ7Hd0q2NmonNAIchVixj5gbB4zktUbdIaMOHw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.1-rc.2.tgz",
+      "integrity": "sha512-k7gIeD/+zRF2jtGPi5tG2vZMUkgVnS9HYPA2yzwB0ilB1NhvL/Xbne1Y9vO4aBAakFE1Be1/1RMIKW4PMv0fkA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.1.tgz",
-      "integrity": "sha512-xHe2R37UevVNHV0/ieHPdFHuZWTlYIuEYBowLBcQ51Tz2XurWnjcM5CLFr/AChkIuw06dk/Ywm4nwjcCBKgCBQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.1-rc.2.tgz",
+      "integrity": "sha512-5PCyHw2Y7nz9geEUT23et3h2XghJm7/3iWDAKa1/4ldIfCnjfxiZ5ZNRdZ9Xxpj32tBmh2lc6yxIJwrtepIyTg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1432,272 +1432,272 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.1.tgz",
-      "integrity": "sha512-U1T7BRdH5TaVg1W2YcBUAQleFEw9f47DFSAYEpyrcZRJX21p9/Zh+ZZErQAR9A8BbdiYOP0GdUJ28EPiEQfxtA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.1-rc.2.tgz",
+      "integrity": "sha512-zUtgUW1N9m+rnyGxVI1uXmXxWA11JxK0/W5sI3ZiwhIzYJNvIMtkMyBjsoNVOVpgd3krwViBxFfbFpP20ew4pA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.1.tgz",
-      "integrity": "sha512-q3b8QGGLvf/zlztdFqmAonphDbt66GbDifOvTXp+U9Stc3cy2wAvImyFUMwxM1RWdI9tdozrJBu3q/u7UVrVsw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.1-rc.2.tgz",
+      "integrity": "sha512-VA6tXDGTgHUvudrbPqgvUCnZcuJOc49OTm4k2tGrazm3uUdO7W5uO/VeuAVD8eEA9afS/0IBqqs0WHc3Q8Cojw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.1.tgz",
-      "integrity": "sha512-g/LzjEqk9Ba+RMBCKYCAlyAadG9/9biEJQepTDmbVUrfjo6rVS9tkpuMYrwpHbV94r3wSCBYQ2BXYM/VubgC/A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.1-rc.2.tgz",
+      "integrity": "sha512-O4fd87GB6Pt0+FgiiygbV/5+DmLI+sPHEBOWouyWqkDKZ19pgRZ541FpYNOmxf6Hjhf8wiG+Zpy3CYi9+n0+vw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.1.tgz",
-      "integrity": "sha512-PrudUDCCLHLKt+QGODE3udg7Ce57s5mChZa2F0g6Anp1TYpRmRWbR/ErkyeDMrvAGllg0PqeVFGzaJ5O535gGg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ubC7861LSIIKLR8AU/vR/V79tOffQE7bhzaKbGl1A0IPruCZCFZiyYD5J8P0RPvWPSaePXjF/P49or5bF//tdg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.1.tgz",
-      "integrity": "sha512-hQZ27T1+nX5B6S1ookTFpnobAQY9XrsFE7V0XXOTzGbDM6JbMhndgA8XnuOoAjVl84c8AkyBTJ6QxInJkF3HJw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.1-rc.2.tgz",
+      "integrity": "sha512-nyoloPDya2sdsTSn4cFJmJBZWpr2EVgJ+oWAkwIrDGWpDTkQXaX2G44bDmMZas8dY6F2uODfLIBp/rYe4ZdPOQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.1.tgz",
-      "integrity": "sha512-QvseCqtZXE+/5DGHEQFG0FFtXU/kBkCEMODZOwl4bJwRWGjM5xEpHfS4Uqkf8x0VXsIbjE6txCmcByRLknkmuQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.1-rc.2.tgz",
+      "integrity": "sha512-jro0WgcJdi/ClpyKGWg+/0nEq9mmcda1KIoMsB+o9lLqebDUce/enxdEP0UtIEpQVOJ6EMMDY5Bsn+WtrdJNhg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.1.tgz",
-      "integrity": "sha512-baib2zmrD76/WMyBfbEzLSZMRAxSBYwgjTw1chDCo/2dYywwM7udfyb5WNuzBa4/e66xX0PibqEmsHFAW4mTww==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.1-rc.2.tgz",
+      "integrity": "sha512-G2yJqYpvfEvqSSJ8Rl61gSfoCcX2v3yGEidKzN5InbS0mcewMqLUfn8RihV2fDKu6UG3nggDGN6aahg0csq93Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.1.tgz",
-      "integrity": "sha512-cqZj1SRW7Z5I6imNt0BjVu+S2SztNi/EQ2vjl+OqyVV6jLxJKYIhYIFOZaZTHuUpMb6NkxIO8qfPDBqFWE9F5Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.1-rc.2.tgz",
+      "integrity": "sha512-y7xSQyQYGuahLyJcSXpB+JbH1F5lGEc3L9K8cjLy5vd/L9N6gLFLWyeGdlGxxM4jxRt1+rAHDDZ/zl7b8GC5zQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.1.tgz",
-      "integrity": "sha512-DcaHmqROaU52mKM1ZuswWMNfzSABl0BrGST464KIKEzqHw/KOshrSKyeWi/j43I0TT8PeaiV5P+5m89QwPsdUg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ABh9GhtUmwUXtBMQg/rMrTgyEXrCIuv7gK2UGJ2waurhblSrw2br7EYqTcIsZbVdFIec9+sHHVCmowqJf3lGog==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.1.tgz",
-      "integrity": "sha512-VLn/XtMePhKMs2ozaoIUbgwsoLMQxfVNt96FZJEOCzctnXzlhehf1nVbEDoKR488N6yWWwKEXZSO6ySAuijZgg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.1-rc.2.tgz",
+      "integrity": "sha512-CEFpGeEL6gtz0jTRWEpHcEH1cBIwzY9023vWmgyjjcFDOcaKv3G324n+IXweHDttbWGSKdtxfpi4FMOu14W3Og==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.1.tgz",
-      "integrity": "sha512-yOiXg2btX/htZJ5Z6R4NffOvJAKFRI8v0HczblqgGaHeSwYjZW0vasZ4dfs3oAWJxzCZOfeLHGNXthZXmHnQMA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.1-rc.2.tgz",
+      "integrity": "sha512-dR+7VNod6b1OU3NF8eeAC8if1K+Aj8Z80gj/ly5sBcfV2ezRuhWMwiazFrQfFum5k/EDuoKTL5lOt3pciWEu5w==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.1.tgz",
-      "integrity": "sha512-byrSXTZnICVE7mtD0g+l4blWhNAUKFcN2y8akQObhLeOjxWSw7nTLxkpsjEyrHe8M0p+ciX8lLCmUn1N7jNsVQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.1-rc.2.tgz",
+      "integrity": "sha512-1kMI5AgyX3LPdXNEr75CaLwC40SIpYUCxWkyVO0xcoZ5VIXuB/E9jmBXTkEXS5US6IzSHWvam5Pm9PahPwX/dA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-reference": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.1.tgz",
-      "integrity": "sha512-hvsaGrNJjMOfnRJ5Uawhh0Ujf8zC69cSWHV4i5F7S7aSNhejrWDZkMIiHLV5hvg9GgRbzbQjdcCij8nJz2KpNA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.1-rc.2.tgz",
+      "integrity": "sha512-45Fsle7tGJsIjODdFFESK5PvO0Uk505UgRAy8vKUz36VGUl4v5WpofW562hFSaDBkUztbJQ6/UpCeEQnWs4bjw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.1.tgz",
-      "integrity": "sha512-vF4l1it4InbuppD7Nnm7Nc1nWteqowTYBsooBdiRfwjet1fPL6z/Wmd2eV7tUgPNZZcWpunkQLhIzR+4D+Ho+w==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.1-rc.2.tgz",
+      "integrity": "sha512-yCpJWKrA4DLd9lwHuUUIdId8H9Vcoq6xtQoNh3UxOYy4KDeoKbcMsRpOOShlnkxdJYGKOoRk3GpRaDw5RPlrwA==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ORGAHRQ6aTWVlUYYTqlAmV5CI6/E1OCoJsE7rbeufA0zGagUx/bAgK1l6I3bzSGOVDxJ6ZRhwOxJWg/3K0ZBig==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.1-rc.2.tgz",
+      "integrity": "sha512-WqEQkyjW467leTJoA31BgqM+nALI3JnrvN1IXDhJuKd8E9nXhTLJcRgDrovEUkh2cjbHF8g8gQJ5Qafg9PzJiQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.1.tgz",
-      "integrity": "sha512-xFRY1mS71lRJtQiBtI/EFE6R6JymgjO26Co3h6zPwlhMbiLvWlq0hL919j8YQsiHOUEHdlLxk2FnjJc2eyYBTg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.1-rc.2.tgz",
+      "integrity": "sha512-0hXnCb+nKBdlNPgblzhckUQNVrUsfhwDWsexYWs2wFoSWcfALfwjwgN9ZMwS5dj9LLvl/rWib8w9a4miuhFENw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1705,115 +1705,115 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.1.tgz",
-      "integrity": "sha512-E9CXWfP9lrdaeYlZNhCSYcl+nIirG/cO+r5je6rOPmfdvupyvkdrR5w+Co0yDKjMjz9NsZ1qyxNa7MFxC3GJwg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.1-rc.2.tgz",
+      "integrity": "sha512-LfGTsbJpCNG0nhT9nBzUucVxnJ5tlY78i5JmlUEb3fwEFUM2cq9pmhv5sXWFdn3LOAnGr0QcyTm+08iBubc6zQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ycCL9EBBOCEZVJQfG9DsK3CAZ84s0/9tByY3csQXsALwDImBY1mPPmI5xp3ITJF28HYu6GC9CjlsZ0Q4CM/dXg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.1-rc.2.tgz",
+      "integrity": "sha512-HSxcn/UbifCGsVSYPxd2dHlURTOqRQ0a907rmQ5TMdPCabEauD+yc0m910XcL+3rRlyTsfW/Vy6AjpNK8cAeJQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.1.tgz",
-      "integrity": "sha512-0Ato2FscNSwpO7MaZ8mI5QtHoUvrgavuhcnETVfOlSBbjuqACZyGxLjWBaJ3jc+6RvsZTidg4uYZaAhRG7N2ZA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.1-rc.2.tgz",
+      "integrity": "sha512-NspsecIb4YdvE54jmaGBW/MjFyuu/MwUjQeM/I9iAgMOpLO+jOsoCOT4M8Su1Nfy1bxokgks9XcBJOcNGjN4Vg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.1.tgz",
-      "integrity": "sha512-5Osuq606H4ii76cBhlhZHk41uEhwGjtptg05GZcFGIfPAbS+8KeDp58kwFzgKUyGKRtiYb2ssG7YQagaeqO2Fg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.1-rc.2.tgz",
+      "integrity": "sha512-UCilyaNPwMO54JYtpCW5leLL+ecwtoRd4sHNVNG94aPQAqZOrqH+hqrBBsuolDJ9d0cKG9K5Mtew0fPz/hByZA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.1.tgz",
-      "integrity": "sha512-UXkfLRMLHvU29l/A39vdU628vCiRKce9Wa1R6fQK6PbryF1fHA4u2btxTQyX656YadkGfpoRNbKTrwuHwTT8jg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.1-rc.2.tgz",
+      "integrity": "sha512-LMpSKA/QIqsv6uGawiMUOY0wgdCzoohBm2Dg7+DGvMmbxdHiUkp0N6HM1SbgO35sS/KP3qBmyDmDrvHrye2EDA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-jtqR76/WVoFeuNFfHEEU/0lmw6ywECVRdNjNbr8xF4AFW7LNDGfIBjOW+r+c3VYs20uXe+KieKCE+hTtUcqYtA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YvlWV2GpDVKR/0Ay4rn9whgPx1o0cLBV1TsOzGAp1yQbm2nKjJ3fUJgwcq2Tf6LAZLpJqGxmg8ji0upmkLBjUg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.1.tgz",
-      "integrity": "sha512-wjIkWDEzv3vvUnGtQi+bqQOrnDcuYszt/5S4e1hycctOYP2LloGTW8I7ehP8arnfPb2Du2eiPGXBy3dVGPa44w==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.1-rc.2.tgz",
+      "integrity": "sha512-gRKI92D+EZtOy7UBkRfNvyL4e/3HikZ7exQSfgGpLEJ278/aXMvStNbL5ZgWVC41+MSZsBUk3dZAfbXNjelz2g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1821,38 +1821,38 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.1.tgz",
-      "integrity": "sha512-3s0w6rdRzaSfTEC3wJXhsSzT8GdIAkTeuwWLxPDGF5xQLVAvx8gAPNgnQ75PSJWF2H/jeZ8rfTNGHYF/AZ5p1Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.1-rc.2.tgz",
+      "integrity": "sha512-JLLkipHwhpjJsUTECuS7jMq8z1YD9CVYS5ZRZvIYvOd0OxgvBB/ga/CJ5MIIBQhCj8/gLvseAOiqV3wm2OF2Hw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.1.tgz",
-      "integrity": "sha512-fluiMLoPFtGnt8MBMoPFzEgjzGQJpUJkLbEC9OQSvBi6MXiZk5oOas8fwH4ZwuDgw0Ef6TIBFxOsbnhfLX6A+Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.1-rc.2.tgz",
+      "integrity": "sha512-8w8klclVCsqqVM6shVWe0vXtfs6pfEfviKHXPLtX70J+yW042wrRkOqcNh61W14QR+OCfq75TIJZbNPDiIf+2Q==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.9",
@@ -1860,13 +1860,13 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory/node_modules/@tanstack/react-virtual": {
@@ -1910,186 +1910,186 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.1.tgz",
-      "integrity": "sha512-dsWyiL5shUua/VdQ07p1m6pCNlMkC9Rqr40bjgvFYYqHHvBchqUV1uKWBKSuS6QYSw/yRdk8hJOPtGnXtVU33g==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.1-rc.2.tgz",
+      "integrity": "sha512-rIyokmmWzOvT5W4zBRlPEs84PtcUXKleGW3oABHaAyIidCcWylT868xzXtUiPBh19Wkr734sZT3rYppoC9fqmQ==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.1.tgz",
-      "integrity": "sha512-fX1uEFVgArjfkmsBzYWbmg9bKYYlmF8UVH2QDp7AgyXc19TJF0I4kFMD1IH9it5hwUuZvPOIQynfnZnwT0YenQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.1-rc.2.tgz",
+      "integrity": "sha512-XuAZStSyy834UdX3jcobv4ZleLXcuwGsn9BVk4/SSi6GKOG1wzsVgxJFi7IhaKGURxuCpheUQKe8+TuE1ScePQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.1.tgz",
-      "integrity": "sha512-NHbAXB4JfQb3AWfzF/bcRp5aq2ETDx33oWALkW4mGWZi/amHap4WWibmkhXENc0oibJ8ji9AFj1k87CVgHsCVw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.1-rc.2.tgz",
+      "integrity": "sha512-k/jB5ke2e+oNyNKzu4/PBlriwCHKVg5bY3kn7Co3MtWZdqbJ42hfwZkRNMnn+nmziQXCVXWRzuiHZt0xNTAveA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-cmdline": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.1.tgz",
-      "integrity": "sha512-w/z8Ng+RRzRrrTodOU6/LjuOwaN7KYOiooxlfCfKqf3S3PsGWzUrvLTsenT9/SCa6W4K3OI74y/m1J2o4xAgWg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.1-rc.2.tgz",
+      "integrity": "sha512-0/dEVUm7Xy0aBo0DBqC5F3kxC5ahzKcmHOF+Q6E1lBqTwN2xytGYTh0TSfj+6rS31jDqxeIvWxy35bLl83n/Sg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.1.tgz",
-      "integrity": "sha512-uha3FJobyShXIMfSuyGCHatbcfY3PA4mATS+hu3JoJy/+9w2Hbish89+eTZBysA4XEG+FRzVVdz9TbAHP3UR9Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SgFresqH5UABzRQZ7tOfqzOLMHF7089VeH+mfcwNQH5peOavgEKrAGOYz/9RnISH0XmMrj/x177t8gfO8Uvo/w==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.1.tgz",
-      "integrity": "sha512-jVYt42fXeAgujQ64BznB8FUveil4D9u5cfYXCnTz/cMMpTLNlDIeF8Puj5b30w9Cn1B1AlL088DFxlE+Hk0F+Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.1-rc.2.tgz",
+      "integrity": "sha512-wE+6x4yGsyg4kntVQFOcb5PiAg2Wb3gs1UNY7SHWC7WOcWCAbREZRfqaoAAxO7AZuqlFhBou7wWc6dZqtGENkw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-compact": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.1.tgz",
-      "integrity": "sha512-XETnZp1RAgLMM4oRJxFmIngQMJDT0Sm521GaUfdVLAXhu+BKJxXVcrf4WkhhR1zMZdKYl7aT6TU1IvTNH1H5uA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.1-rc.2.tgz",
+      "integrity": "sha512-rLNBnq5jo9nm4Etw5PrVtcYlFDTM8IQt8w5aL+7CQiEpC6OevP7QzvGrIbJ2VTG2GX9yN6fJosPd0Ky18EQuYQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-feedback": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.1.tgz",
-      "integrity": "sha512-bSSh+Ac+z9JbIoK+guAvX+XUR5avWZrGA4/bTMv3zB1C63+CnAaeU1UgYEV4vDR+sPVZRexPXXx45uOIicQAwQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.1-rc.2.tgz",
+      "integrity": "sha512-0i0EDLFP0h1UpeWq1KrrUXKJFBK7aoCFfzcWnrrD9Lj36I09XfjNDJIm4kcYNTkbOFb4o3MWNw01FKC5rNJjXA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-command-goal": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.1.tgz",
-      "integrity": "sha512-0L0vLmCnz17t+eQGMzq+SrYqBm8OWlnt2xOQKNKR4oe0w5HYaqqNuxEzz8bjVvrazjr+hv3PPQj26uCPctsaSA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.1-rc.2.tgz",
+      "integrity": "sha512-AfiBUOd2QjM2PW73nwQJtSDUri8RtEB6l3XVlznUrfY3VFu5tF7GcFUXffTxgtroWrvaqETs/vQJc/zsn8tGwQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.1.tgz",
-      "integrity": "sha512-jOtQNe5RBfyCQxUqCAhqJbrfM3iUZZp1H197SrhFDuZT8v4CbbnyjBWQTAeuztf66pM8VoCxnBik79kY6tN/KA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.2.tgz",
+      "integrity": "sha512-BOIe4Sht9rmMv1a6b3GWjWBbeWr7PtHlAy41vgpaymvUUuzOapOIA648ZMGCI/crRIt72Umev2FHtSwCNSbYZg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.1.tgz",
-      "integrity": "sha512-0aDCK6TDF2RXJTrgkmuh6KAGLA8jthR3JKNp0be5RS1U2IIEXwjOLwr5ol4gvSaNLerMlcyLyslkATrHj8hQVw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.2.tgz",
+      "integrity": "sha512-LV5GAIx7GO8DCRivnN2bmLmuucsYDG+ifG18BaXBqsVKdrzmaIu5o+CBxQAI2bX1N6mfBenLxmvCnROkyumLTg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.1.tgz",
-      "integrity": "sha512-dNi5IZg0nOUPckhOSgEltHpF8On+wEkMR4gMVF0YItYJifReqcj1qHDZ+8jjmDNFTT5lnOUXylMXyY08IM1a/Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.1-rc.2.tgz",
+      "integrity": "sha512-qNg4JqWlZ5NvlFmaVZtJ+RuvJUtYFgdS7xXlhhBGSHbMZi4sHgB63Mo+9Y0Rl8glLSxLjo2reMMPlECN+duUuw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-compaction-tool-result-pruner": {
@@ -2098,42 +2098,42 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.1.tgz",
-      "integrity": "sha512-pRFLE04eJRkH46NMH4F6HvCz7lQMxdua2MifcyAdfuHLRCfGtmzJtlkNJkHd7936rJqHaRmVUz3+UMt86MbyBQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.1-rc.2.tgz",
+      "integrity": "sha512-HUS95EsuveR8fuzaZW0qSv90mVWbv6aj7W9zfWPbr5BmLJsmomQlw6jFX3GodN1Iv8qWtrzFkMuxDHk4ZTHcAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.1.tgz",
-      "integrity": "sha512-XunBtjdTo5chATPwwUDNLfz7lIkdGxn4OIEHZ6WQnXl6sCgd+xy2pCjBH0j6wdvWO/xo7m99FPnlOCW6cyiing==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.1-rc.2.tgz",
+      "integrity": "sha512-4/DNA4fCSa1nIb52mbRT3TV8wpsnDzjMRJfPbffk8+Fv/bj50jaeQY5yMgUXsUYWX98/RlekXTK4u4LdjtyHKQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.1.tgz",
-      "integrity": "sha512-PUyFU5PFleIvjxTZpA9v9Tq9wCsESzQnqwhMU/Ir+CKtSM5EcMsQPCRD4HHnFqrVCIsQYyDffBbWr1K4LziIEg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.2.tgz",
+      "integrity": "sha512-+AQGegPy+gdtcjTTPxDDYwAFUn6BB1J/MFFbmpPr+WIqJoDyVsuCDe8Rr8mCJmxs12CmTZXXSOE03LW203W8fA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2141,31 +2141,31 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.1.tgz",
-      "integrity": "sha512-oZPts8lYYstp9XE0N8jYziEQQcv1+8B/BkKfT2pr12/7SeQjAyduyIRlSOmc/UFWEz254BLDWI4vtnWXkJVazQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.2.tgz",
+      "integrity": "sha512-aeVBaH07rox7NuSNbSqbz8g0eNb2IIhNbrZngj/VxUsr/TR9TXOq7lm1CL6SBUDlstGw3vNWeXyhim/DmA5iSQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-q59hxIpWTHHrFmYS1k2h/d9aNEKrq0SA8At4sxM0Hpx6/JRBqvb2AwR+m61eOvwBu2HApSY/oHjrgrG9JukQSA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-xlDyX9BrfT579qv6ilh4EsqtMs4A4oYsuCYHvK8UWQ6YRflxC4GiXDU44iNfosQo5BQwzJzUlBmwHy9id3e71g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2174,63 +2174,63 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TitE4FzwV4JPWmXpI6Rinn+oVt+0c6DtjJCXdapafNHaYKUnYqFE4Bydvn2hDzLKnkwEgEKEugSZLRno6P91bg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.2.tgz",
+      "integrity": "sha512-8Pd4SNHhV6OlbwfV5K4qmFb709I0Z68qgaUQJ7zM4BTjClNe1/dktQnETtWPfqbPTx/2sNKXM1rz4WXuROrIfQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-+aLtZet2Al71eRKeFIhYXHyogYLvN2jIRcyxPF2BirhwIms5wIkRQsvXdJJPKr1/p/7wi4pS5FmQifDR1Tq6Lg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-aFOn9vsRfjWJYJyBLLD/kItD/KxAzxLNpKTUlxy8mSBMPUM5HEpUkAopgOg265OsjfvKdAVSt+eY1snrURXNgA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.1.tgz",
-      "integrity": "sha512-cf+F+spDreyKTFYPYZ5DshRJuq5+H1Wu5xD8078zjy5PO86ROZRIvQl1zc1D8EnWhGSL/8rw4uCuYkhIZNcicQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.1-rc.2.tgz",
+      "integrity": "sha512-8j+6MffvCHATLQrhAVfc9rKyunKu/O7mjjJzmdsUSdID7V4iUYMwqPamhlAyI+tfohZu/vcforKzCRIZGmCYug==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-1vKUUxl9gZ0xh/wniBs0e4/h8+BEBHuBrIhpgf4Jr1IuPJIQbzTDgJVvFM9657zWxdNzcmb+5QV3N25GWcayvQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-jvn1MsAMqCmt5SjRNkPjmpc+RIWrZQrBVtf/OpmKr2PaBEGqSbCkPApWDE9iSMhcuQg6k5evScOXwAsduzKOLA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2238,39 +2238,39 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-CsECIJkcYcwfXpQa/8stxEdGifxa/2d2AJcUD/ILR9NcHTr1rR0UjyJ6dZREtEhclLz5HrMois6qdf0r+TCo7Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-rlq7yu4xavkKK1Oa1/aNCOeUW7t/3OXJJOfOcZXuUgJn5f8G0AbpTDpp2CeuL1cHlKpbunGhEkKQ2N/dv7ZR9w==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.1.tgz",
-      "integrity": "sha512-tfWU1aVZRxW5j/A9zEaPQUcs//jf5XhnR4QAmAOXtY3EvgHXEXjaJnd9mfKquMZtvZEr+4JWVJo/aj6BERch7Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.1-rc.2.tgz",
+      "integrity": "sha512-PI65uLZ3ARkfVV/PXvACS1HEXggoOaXgYQzXQFdLOfm7AiHOdZWZccUAXBetpZhcNYIOKsVoLnfZkXcHByqecQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.1.tgz",
-      "integrity": "sha512-kvrZVsyOe1ZDgYyFMKpdhOqn47lMMP88wac66suQrMPLI/zQeHPv7sTnQoV5BceQsWln/N2Txe2iBXnmDxgsQQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.2.tgz",
+      "integrity": "sha512-lSHTh4vfS6eRb9to/y+bjRf2+0QkNpY3tHJ29HMTewR9fJYZsEVVu4Hc+GPhPEjF7RpiD35/sKx+akijtDasyg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2278,49 +2278,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.1.tgz",
-      "integrity": "sha512-BscFM96Ud1/txqIJD2t/atqTrUmlDLd29K5fGhGmm83pOB0lHqCJ6T1mfoLrT96KIU8+x04ubkfz/63xXjGllg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.1-rc.2.tgz",
+      "integrity": "sha512-pWipAFKx0l+ai/gJvNQNNk+ukHkb5Rb85llAhJVwyk7YfXLC2G8lIfnG7ln58M3vfUKuLxQLE/GL1Qbr7FQuyQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.1.tgz",
-      "integrity": "sha512-4ktB7lef5PXUXy94eylGwGCYwMOCGjsfj7WE3H/Zcg5yXs02rZZvE2P4PHYaNvlnizc4DDlwJpyNCc+TI6PtnA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Pk50xwmUUehOxNe8DJ2/tThj7Aw1MmJQeUkfAQh9miF7Tm+WOOxiOOei/H4wjH9cf+FuqtbLDw6jrHmGotfhjw==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-headless/node_modules/commander": {
@@ -2333,131 +2333,130 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.1.tgz",
-      "integrity": "sha512-C83S3PL+S0mEC66nJO/VFsdkG9x41tSGKmrZdanTCA5OEp/M8OJYRZNYmsUl48Xwe8wQfLhHOes7FVWtRDRcMw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.2.tgz",
+      "integrity": "sha512-lGsP7sbnu20AiRAb+gxYiKx9oa9r1D/8Fr6BwWHXpaPx6ZE4Qg0+ybh5SZVfGQ+XhLcQisu3nwWemEjtTJGiig==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-pVyVP82Ij14kniqMDHGm/0Z+DDpkwJ/qHbLGe/G3zh0fpONPznUnYc8Qy5S88S7LKJy5+lLv0T5C0P8w9GtmEA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-dplRnGGXXsQYFQ1KMHymAM0iaxuE9Z153JHYcGEgOwXNkS3HA20gSi3yMt6fz+zi/cMHYXvY1JQhS54BTc761A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1",
         "fflate": "^0.8.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-permission-presets": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.1.tgz",
-      "integrity": "sha512-PrlnIxKg6WqPP8WwBVQf5TNRIxhb0cuEEj7JX9eI/rycVzNSRmaeJ/vTyoOVnw3lUZeI66nFF7PAOgJz0Ojn9g==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.2.tgz",
+      "integrity": "sha512-m3puwS+bvJQ1eASdpEEwlQqKa9znhBSgtoSSI0GZN5VMynZVl7E31HMltENz3QC2Nd+C3bh7vNjrJFtumUDsLQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.1.tgz",
-      "integrity": "sha512-9WDce848S1mUkswZKiFGS2xqjWBDYakg8xJoTtGp11b0xcgjITJNYRJLTrffqZ/FgPMSu0Ij3nn/ypBBjv+Xag==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YW79cegRtVJ3zeVEvYPCpyfIGZV8l5iXUfdm2DI2lwUZsbQ0ZH09AeeLyy6fREmbtuy99l9MExKG1KYWl9No4Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.1.tgz",
-      "integrity": "sha512-6KfMYkD+XUSUXjGff/EGLjpPFjU3lDeWoFzyCde7g9aLy0RfEYCSAJtcXUCZID+Z3PPwIfssFCwPn1H5ptyFHA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.1-rc.2.tgz",
+      "integrity": "sha512-iLIXqO2fWDsItbtiNPE2Yv2KK0u5A4W5xDbNgd9jpLvzB9vg0NLv4wG9zI4azQ0zf0XgmfPt7BK7UpMM8iStKA==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.1.tgz",
-      "integrity": "sha512-dZs60Hr6MNJGzroTrQ0I/FD6IDcHwBFiyYSoU2GRunWKz0tdKLWAADHl1eT4mfQay4VBrl/58E+9T5loYWtuFw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.1-rc.2.tgz",
+      "integrity": "sha512-EvCe+NWYCMvJM1FCZCqrT9ggwcQjCGfnI+9t9F1ZIXbjmnhTD1X9K9xt0Ber61lO7ZN20h98Hls8gkzWbHt42A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.1.tgz",
-      "integrity": "sha512-efJSWiHOCPZYG+IAE8xR6Jm7x9rnO6HH3TYsBffL6T2vYlxwpPD7uifUDgHVvyVmPrgAMsPeYhI/0tAtZm+nJw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.1-rc.2.tgz",
+      "integrity": "sha512-KmdcBiprbRPuCK2d5e6VmXbXmT6fwd6nwGtqU6iOxh/Tl3/1V3c/lg7dvJu1LeOmyw8epXFbzgEQNw5ATJtaBA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.1.tgz",
-      "integrity": "sha512-VKQPlWcxQTKZIGDvf/yW36GGk1iwbMLFIyWYr8Q3iRCYSlGyL+JL6ejJClxboVNWiZvPM75Ywai6HgkpLbLgPA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Hud9ezW0bexWfhX7C+c5rdUDX1xzbEGDzj1lGQyj/QxdrxHYHjGrJq3tLRyvN6K4FSmEdG2IBKdQGCOLVrIthA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2465,28 +2464,28 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ugps/tmxbOLqbAf1s5sCIdfrlLpm4rHKm1OyCCNbKg3MB1YoZRqa+hH40Usf/VxzvjtP8AVDYzcYnF7vwAafLA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.2.tgz",
+      "integrity": "sha512-t9MrjC65QHiiWhG9V8UZxgfE/aWYhJHHrIM0kbTvtXxg4tLGIKo/upHp7iiag65F3HTkVLrH/DUyPMi4v2ZA7g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.1.tgz",
-      "integrity": "sha512-tRsr9Qynl3qnFAHE460uALI9jncaD0pr4+hufWTSY73MbOswd6V3KDYy3wWQb9ttDm5XE5GTkB/a56KNnO28XA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.2.tgz",
+      "integrity": "sha512-l+1Om/EDFyMjhgSuEx2WDLLA2fia/+ga9mBTCoT/MMslsnWaK5G0/lWwbwlTBSaJ6OfmYc3DuBgox8DbgIGHRQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2497,65 +2496,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.1.tgz",
-      "integrity": "sha512-LbETHkXkI92vTQCAnOqsmt+W2pagu0PlVw15vGTBgks9xi7YweFQtGPfsiCJ0EHWaiKARvqtT+dN/n0KkDyicg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SXvDJMvcUrGrlzIyE7j8/lI4Pj1nDe/UOR8C05Zagp+/0R8p46n6KylySvZdPAFENV5t8WX3Fw3eOaS4No0+wQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-jobs-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-xjzJy3yhqdUDTo/IRr7cGpnE1wzVRF7ZABcTiCg2cNeYGY5SzGoUn/XyE7kOsPEulHbnvpr2pddHMJvwbBcGPw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-26lg7mi9RKnu8IP8SWLbY+uZenbqF2AkAZvgZaLDlw1z58NtBsbgKgh6FNC8JXEyknAwYc6auQQKF+nLTlEjCw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-launch-environment": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TKrXFGcAibVAWoqjlc+M7xRfr8IVdkzMpemmSkNpXOxaqLVr5KLVwAOL+Fp05knp/riV2WX5POucWJ5L3P3gaw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.1-rc.2.tgz",
+      "integrity": "sha512-LIjPUPwaZ2cIiz98Oqxn9TDKXhWlp+0EGmUhk4RerBAkqRVtDl0B/leK1pSZLLIR+qcr+VAwLGJagY8Xm9XWvw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.1.tgz",
-      "integrity": "sha512-SzZ0WHjxyfcB1j/aEkZM/P5Sd11qw58AgB7TFcRC0iHwZtAqlKMgaptx/Rz1olNyerGpjii2mmUoinF5p1MYwA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.1.tgz",
-      "integrity": "sha512-qCtJgnvY6ix3hXX6tRcVozoi+JL8re4PjpNnCGYz3Az4csqdIkL+a9DqnV8JOIMi20NTjeOrktaOFgUd7rdsDg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.1-rc.2.tgz",
+      "integrity": "sha512-GH9AukC2kozv6Q8/9DDhACHSe7fpTG7o0iWGUEN/m7/qajCJ8abySOFi3N7otdVmolR6Mvz2GZDTn2HdHqkWWg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2563,20 +2562,23 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.1.tgz",
-      "integrity": "sha512-lExsZIY7PeL7yEwgglTGLb1Tbg4soANFpuePOONIrn1ZP51DwENw1SrU/0RK9ps9ksMHyl9J1ie5FIYS/YCY0w==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.1-rc.2.tgz",
+      "integrity": "sha512-/02zlUjTHlJkme5+eM6VFtuiK6TacI5rxwIWMaxItp/s8rz91grzWir+qxRsPrz6XIrmKXagyvi3m/tuRCtk5A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2584,38 +2586,38 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-authorization": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm-retry": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.1.tgz",
-      "integrity": "sha512-9bluPgwdzU7HIteYvwmLThzcT40nUBWDCrUkn7WjckuWnlx6qCIz5cFKeh3iyPPIHvcD3jidMB2ReOxKTEy4VQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.1-rc.2.tgz",
+      "integrity": "sha512-a13Fpmn8HFy8LCjl6gljaNPxcVjO/R+/uMPDl0QLjwQcHWVyGW38ZA8jP5iRuFgdyNNXpyxLWuZXi/0VOH00tA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-mcp-client": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.1.tgz",
-      "integrity": "sha512-GXifDFUgiWcm3dr2Cbnpi9mbQgzP3GtIpGSX+7RlXlCHIHuavXCdgvGHSbq/KGPM5vAwrkZS+xcLwTSqpQL47A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.1-rc.2.tgz",
+      "integrity": "sha512-oxNes59UTkXuTmOqQr6+GhZW7u2JtqSYiI5eZyBQ6K+yjPEQESa3/rYnRI+gHGAtx8EFgn6hsdOS5uoEwtFuXg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2624,18 +2626,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.1.tgz",
-      "integrity": "sha512-uG1+QqnlA7pTLj9ZffQRfIbZDrp7kHnquWotqZkc4EjLF2sCwWDB7YHYhhszjTbfOY4QAWk3tWvcszC0bV1H5Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.2.tgz",
+      "integrity": "sha512-GzxDiNvyUVs/bbbm+Hr3MfuU3wM8ErRF5z9XadnSGPYZvipZDAMrvrS5v6JgOUaZt6ApBpEMJ4xVgIel1VnGYQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2643,40 +2645,40 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.1.tgz",
-      "integrity": "sha512-maVhsVwhIyGuqcMpJWMv4BPc/UaIIdAT4aZmdv9bHzbj3vzRALjAKOEAdhIXtdxtuTKcYbimg402bbEwe/u2OA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.2.tgz",
+      "integrity": "sha512-GIknPrwU7vZOUQ2o/ES7Z0uUhUrZGp/yigKP+RXEu41VI9tcybiXQAA8CEdDFmNQ11R2wfYQhr3WO5vy35akWg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.1.tgz",
-      "integrity": "sha512-FapYBIWVzcXioH/lTaBSJlbEM9VQKzSy4fQgzRDLAVP8pMAHAvTaF/tBGQMooP582sPe+XpGh0xwWSJ5X72h6A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.2.tgz",
+      "integrity": "sha512-tCni+bTEp/FWokfz3fqn4p6SzHn6pkY6H3HkS9UY5PHrztUE1ESUQUp41kIVtwUhRmJU7yissqjxe6kLDB6t2Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-permission-presets": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TSWcoxXBD1PQg2btZ7cMscQSHBLAz480oE0PV3ka/kgrvBgppwtppQbMoF1owPek+cJ3EraXthXnUk6IlcuPoQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.1-rc.2.tgz",
+      "integrity": "sha512-k9hdF0lXV6dmVNBeWTmJpk0okaaH3hnvpQVRfUja8mlpJgPr482QMReuQsGJkY8ztzSE+JtzZndPSXjRrvLzSw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2684,50 +2686,50 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-persona": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.1.tgz",
-      "integrity": "sha512-RrP0ABGoVvy2G5i8B5nssDpgpFIwNGvdT7wPPN5ID+wnRe1TD8PwfM6L7ZsTpNHKlbpmZmNfRxlEE1cRm89XVw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.1-rc.2.tgz",
+      "integrity": "sha512-3pQjr8qSCVmGtExX9WzGNF9tNHKAFjtDyX6g/2HY3Br/hzANfQY13F/HqdjxufB3K0Rsu4CNkq78TyweXVUZew==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-plan-mode": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.1.tgz",
-      "integrity": "sha512-VtmkzVxwYShRNrkN/1cdLIFaph2vQbm7o5/8hK3elXVYOTd4Y0q3H3LduPMmu1Ejnj5trDYqUTZ2A+vPob5ZzQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.1-rc.2.tgz",
+      "integrity": "sha512-jIQ71skseprYkwcIkZfS5jtClF6Z5oDC8JIwMN5ukGRDkkoKTT+uLWnw3AgArAOBi0CIy8j5Khy7GP7v+02F5g==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-commands": {
@@ -2736,200 +2738,200 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-Wl60ol6xE51HXjrQznD2dlvU7aH/mkKjKwaL5rQ7M/1bfmqOEM9cCFVAGw4uFH1UIwoBF7Z6lDTfdgpum8eFjA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-MtX+IN0dN60n9F8A07ugz4+GptSaoj2Jyub1vkUFkgpdiph9lDAh+PVVG4EKrusu5YG8eXDCDDnb3S1UNtrNiw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.1.tgz",
-      "integrity": "sha512-Sh1M2I98i3bPmLmQdhmcbjOTJltRL1ygr1bSx46XR94Dqwa1DvmCx6P/ZPtI9I5KQ05u0Lq4omyfTJ3R0twhIA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.1-rc.2.tgz",
+      "integrity": "sha512-hBUTg5p8TTQifZrfstbimVlBFyUOb7JhNkWKc+n6UpTzoFRSkPAvrjGeXKDmFI6jXpL4nXzLJoaIssfYnRg7bw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.1.tgz",
-      "integrity": "sha512-b5DPzJPJTKACT2RNmdTBRvo8ajkJ1n+UttlH5tULaKepr6AdTxxvq31a7HFWMwmHJ6aftXGyui+g7a2PSCW9bw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.1-rc.2.tgz",
+      "integrity": "sha512-alDGjPdN1o7BVnBy2h4WZa+Zgb6yT76fyAQ7T7wN6K9jbnenSuvCjQyhoehhSFZUEl8ldRqaafFhS9ErGpVmDg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.1.tgz",
-      "integrity": "sha512-+2udF/TLxmZTgNC3RFA7ydN2sD/LIAjkao1bUiU372uOTttGrt31kKbeEqXL9yzfdiLjjuXWhRlbtmvmrf5PKA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.1-rc.2.tgz",
+      "integrity": "sha512-rnO2RqZ+ycpwrXrXlMcrhWAICdui3ZVTjNQ8eZrOPE18hAbX3tw0nLFq26sBjMSnBfDQHNZ4VaFpt0p8qhkPWQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-GEFDzS1sRs1ISeWa97jtr3s868WlqEnP8S1w6y7stXIBm4GHzrLizjF1IvYlxh+WyE0rBC5wa0kVSZsjRQT2tw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Sn1RTGRFLA3fB+thcBwyyfDRdpgXJ7/6qBz/piFh+emJ4IfGFlBEUz7H2QfuwOGAmzlOmncxf2brcM5SfAgJ2A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.1-rc.2",
         "@deepseek-ai/node-addon-landlock-run": "^0.1.1",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-0CxwofljyZEAwrP5DboMZdm3NfekF+bDu2A28IWLTkTQKgF4DCekQ4bMf+Nqsc0gxBiLfo1ZcUUFICQj8m6mMw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-cpoIUxCzpZJDTMXVt9gS+qgWEDAWf6rIe715uY1NF0ROoiEXPlmToLsHLF+4pXTW3wWWzpGVswO0bPYEKrQr3g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.1.tgz",
-      "integrity": "sha512-FG6dJCb37vcuujAK1E906v08jtWTV6+54ShftCjqauHXWk7YKtIAsYRwMIkXg32aPD11EvQGtoJE45Rs3XBEdw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.1-rc.2.tgz",
+      "integrity": "sha512-DJ5jI8uzJA2VJiIgkUrqNDo1oKMJMaQ1Z8F7kFpxEkI3IMRSfMyqTur740ERBkX3pVc5uDLx6HNeEBx/JR43SQ==",
       "license": "MIT",
       "dependencies": {
         "koffi": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-schedule": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.1.tgz",
-      "integrity": "sha512-MvX5rP21/K0RqHTYdyMJIUqpM90En3A2CQiCiIc8BDzFqNJQgEE/+PDeHsxXnaPatmLhC2Sw0fQnZaoJxZ3/WQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.1-rc.2.tgz",
+      "integrity": "sha512-I/uuXlZv6gc71SdXoV5sGQhh95nNjhy0zJWfhttfapNvuQYxZEzQU0vTAOsQB5FtdZ/xvDZm86z01/E8+usLAA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.1.tgz",
-      "integrity": "sha512-1Zt+tWDSCoSTAzbaJdSiWHe3pJTpyIqnsCEP3SOyxLIKclsj378rhsrkw+5O6oCRxjDCf0u8BJ+Q5liXREedBg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Xy3ejL6dwVSluZL7XOWy76ya4pCw1uHwxodDK4O9XiQUiUV4FBXnt0aNJUtMeAFN0c1YujxxCmRniMvuuNn1Nw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TypXRsDxHQzms8H44DYFOs3sD/1fVvpFcyPMtOSP0SY+u/e+P/xg/0PgCvEt1epigHkBXtHddjHNLMlhzy9mbQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.2.tgz",
+      "integrity": "sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-RC4X+QWL+mYIEYmkUrd/Jca6y/qgqL8saXm+v9pDU+lhjZ757qpUc+2WNUo168cT3umTLEYOcDnLty203C4HeQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-VmnQBKuWEHD78CtK1W5Auhz9VayTiNQTpbsNFex4uD/9h0XglFxVN7G3/XVUDOp8VHxReV/Mh8F1RS9s/2yoxg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-log-export": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ZrVUSq29taKCbpaD5crG+2XRWyJvNQhFtbdxSqwaroWEsYdQHINVqn5Zjf/Vm40n4MWiZLWDbsNf8ba+CWE3Nw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.1-rc.2.tgz",
+      "integrity": "sha512-IQ0itJ5VsmvTkBZYNnwNIj7h2qaw7dlHrnKt7toUiAc5gC12tFwKouMFdBS5VtOSsxTuQLdnVNPa81XOy24opg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.1.tgz",
-      "integrity": "sha512-EsgGSWPEt+pLBamWbICgISNOpw0f1FVdECOnkbHVL47weOTz04S9SVdLcZv4aMo3xSONbdBAThhhh8DBf6Q6sQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.2.tgz",
+      "integrity": "sha512-dxdYxRfmK5jWtiFFabqRNb/jGGjkXyF2djI7O8IIKmDVjhQiv170zpvhbAhRUuqClEdseCtbQpLBrRm2blzt3g==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.1.tgz",
-      "integrity": "sha512-FvK6nBwFk+tBUIvxL6QVpck9TVEG73HC9VlVvc9VeskD/74/J5FinubqjtER2S5QMVHBrocDy0EkGYqHrJlTgA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.2.tgz",
+      "integrity": "sha512-1H+boST8tlc8fu5VVClcCRFGI18dH1EOAzfC+HsQZ+GiC7jhPN112oJWyzxKot1P07bmKdKev3un4VR2Chr/aw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2937,29 +2939,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.1.tgz",
-      "integrity": "sha512-RXDAUdfi3CqTQGQhMyIDZ5u4nURmN0ChkWwoX5Ph5rITa1zelnQsskYc93s+FTtB9Ituac3Uynk0rKGw/bS4fw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.1.tgz",
-      "integrity": "sha512-eWdgco1blIb+hCGPx0bWy+cc8nebhifLm8FsXrguIJFgK499HZEhDpf8D0veRgmpjV0HhNVMinB0egdXNeg0nA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.2.tgz",
+      "integrity": "sha512-UvCRpIb+LoQI/nCLof17xc2P2KuZoucU3VuzfAukfsF3dYZAy5OP7jrCRdVZIvjRfvFUd7G+awdS9sWbnjcolg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -2967,26 +2969,26 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.1.tgz",
-      "integrity": "sha512-5FX2RunFkHNY75mCK1wrJ+uJkETWzV+p9tbao+L9V23Q6njIYQ6cMZ7QxvCHcMpqZIUvD1muZweau1e3UIB8hw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.2.tgz",
+      "integrity": "sha512-QxQFRg/KnrZnYiO7fNtTJVTakuGs9ZFRkGGgYuNPzSz1pRqiohGNE/JZzBtq+HMv38RRTRZrM4aIOUV8OgqoXQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -2995,19 +2997,19 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.1.tgz",
-      "integrity": "sha512-0qQdWu3n6UPSmOe3FgdELbqOa0aohbcD0TSEu75Cba2e7I5XHQzeKsFas552zKiHmI7f0BconaLKDiHnp7aHgg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.1-rc.2.tgz",
+      "integrity": "sha512-gZ9q3v+NdQC5jaArBMQfpX36wLXXvhtEfKK3zu3jOd9HopYxgNKnm/mUX8Ma9P42gR3Q+m5SGU42pow5vy34Cw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-session-persistence": {
@@ -3016,9 +3018,9 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.1.tgz",
-      "integrity": "sha512-deO+kFcK/ZOvcOwp5wd0tCPL5/yiv8TeE3Pmvd5NqaMr/0vKm8ePeoXwqJmQ+T3cHtbUhukGNvFKiP94IdQaHQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.2.tgz",
+      "integrity": "sha512-c9mz19ndxjVxSnXEhmJwGDjyKG4oNmu4Sfneix8OUJ+mAr3jIgb/QZZ8rYEc8Bi+Dd1z7Wr90IeWOBF0nolU3A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3026,49 +3028,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-stats": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.1.tgz",
-      "integrity": "sha512-H+JqPsq69nnoNPTJBQVQzG8EIVb4UZyyN4teLhEal79LG3XvYn9s/ZWTus3z02//KdwGhetCzvPZ+E1PVaUFIQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SKGUZicnHHU8+zCswoluBCHSbTkA5ARQjl7YNxN6qY01ud/azpPdbcVaKO2MUy60Q1myx3W0Xk93VzF7sMt6cA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.1.tgz",
-      "integrity": "sha512-sZVe8bnMZK38J9pZWrObXOFKArV3aKo4cQJ9TgSmo9C1oAY2Mv0HA8rOodUCBX2u74zQ+LuB455iM9V+SCHBXA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.1-rc.2.tgz",
+      "integrity": "sha512-yYNUtpxykp10m6YVCcfmxtfiRZeNr9g+Mg5/37oO6W5Fs9A6L3vfCM4Ppn47lwLbQetejsR1QClV4P4I//c01g==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.1.tgz",
-      "integrity": "sha512-GMWUdtmqGOakCbx0af2umlrHzduqypxSp3ozYi1OA1KOqxKX3aiTMilcaOQL79/e+/Z0zG4v2PvXKCsa2grAzA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.1-rc.2.tgz",
+      "integrity": "sha512-a+kmjEWvRZTMW/oGzoF0LwlsEOdtr4zCv0PeFPG5+wA3XGqn+uukgh5LnXJt4htApxPfWVj1qBz5GFRgg6MkNQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3081,18 +3083,18 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.1.tgz",
-      "integrity": "sha512-hPtDxVSktufWJdZKE5c1tWRl+lb1NCRcjdXi+Pm8Iq8a0D/yx4YDKiv/aLhklDFybyV8FmtlVUPdJS0teyRyHQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.2.tgz",
+      "integrity": "sha512-qHv+9nE6J/piHsWwckmbJBS1sJjunCWsv00arhsgjW1XMLCHxG6QOB+U48P4EBZjve798Tz8AQIlWZy+9T8XmA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3100,34 +3102,34 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.1.tgz",
-      "integrity": "sha512-BUGmy8sT1IjP0S7slcfBbbjNUxcbSTN/iPPO3itSu9Gvwe6we9PwMEdVQgKozNsaUeax95aunl1KRxG7LbVKUw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.1-rc.2.tgz",
+      "integrity": "sha512-HWgRO5C+xFOq8dEKwotJ+jNj9SLo222EIlZuTCV3kdEjblLkSJES8jmXsahzLsIEqXfwdplHfgpG+365XE8NWQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.1.tgz",
-      "integrity": "sha512-vROiHtfX8VBeRKfDsnFufP23iZHjxMKUC2Fvct9QbWG4iohaAYT8fAfkzyVcZTE3Mgr1AuSzIiRtiwUUheiZtg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.1-rc.2.tgz",
+      "integrity": "sha512-UTdH4h5zuMsNDSEAa3xp6YsfVbLRCCkm/0uBt8wKhu7+rWh7OCgvAgvvwaIKEGST8/8NWC6ogdT2GFNCX4WizQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3135,29 +3137,29 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.1.tgz",
-      "integrity": "sha512-Q7dr2mQQlaAOgZR9UGUQprOQ0iI/NyrsfSWO612/teUawfXaf6k1nO8w90ExDD483wengXp1bnZ1JT7bal9WTg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.2.tgz",
+      "integrity": "sha512-iGdKEt91Im3gE7xA9CzRfTJsPcFcxDeDOCLhAjzbpjEv7TAjx/EoYP7lPtiy+QmOjKSKy206SEtAKol9PXWbOw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings-file": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.1.tgz",
-      "integrity": "sha512-2W85eA92YLsSNBuQHDcmrK3ycWqz//Kke60vlZ1Yo7rCLjxLhCLttEPxLdpmNsmwOOxAQo0KWst0tIpzglmvOA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.1-rc.2.tgz",
+      "integrity": "sha512-6EKER/KLEOwmTkB0AMb/Or/UVkeaqxisZ4WKo+tgsYyJYDTBTDOZjVRz+nedK7vLj1AH8JiEKvmAf6FMxkZvrw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3166,73 +3168,73 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.1.tgz",
-      "integrity": "sha512-3D92e9P6qEfLipJvTSzg5voTLydjxiC5glLJpW/1Jg2HZ3OFJ/sr/2GOIjSNNYViRYOXK9HsfvYURUAFHmQGTg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.1-rc.2.tgz",
+      "integrity": "sha512-gEqPUxKOpOV66wvM4o8Z5FEuWmsEvYzD9OQy3cyo/kjzlx+2+KUWi22cl/YWtBs/zUtRJbdG5UqMnh8GUeO8Hg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-shell-env": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.1.tgz",
-      "integrity": "sha512-wDBqqaXbUggc8mxhmlO3aWoQcZ+VCOIY715L1NhKBi3FmEpmDm4XOoArs8udH1IBUKYIQzp0GtDtLpTccPohOQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.1-rc.2.tgz",
+      "integrity": "sha512-dDKKqsxsbklUpxX5ornd/SKJ2yfr/SOHOWDgeJkYvx3SMSXq8EvhCK/VEvHswXQ25rRLFWM4/Mr3htk1hn/GPA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.1.tgz",
-      "integrity": "sha512-jc/z3QEYGuGlnh0w/kVv08B0vkiCVmXhX62MppSuzK6yGKQQJAYtvw3Trk9q/hYutL3KwFpAK4FnJ8dtmiPB/A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.2.tgz",
+      "integrity": "sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-badge": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.1.tgz",
-      "integrity": "sha512-7evQ5D6krRUbf1FVt1HutKDMecZDQqmGbZBe9ohhGrIQHU12U4Bewb5LE4Tl6A6hKKstnCoY5SbovQIbm8V5lw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.1-rc.2.tgz",
+      "integrity": "sha512-1JL4KdWk8pApJAVGlX7SS7p/MIhFKSq7GgA32qHIKWZBnL0qkwtaDdGbk2mam00NVcfGnpTPBXjwL1kOboPn8Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.1.tgz",
-      "integrity": "sha512-ReGxRVmlVJ0S23lEPWlADnPie4Sff0vUdjt5/W4h1o1wZLyXG4STrCoa4Nkm4Rhx3ES5WfLa0Wr9TPzTkLEieg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.1-rc.2.tgz",
+      "integrity": "sha512-eyQGv4046c392kIvOCom+gvJpiFbkWsf/VqB7dCQXTZrdXEx99P8oOm3jsagnllcLKYyZVVETs75pPgznye/iw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3241,10 +3243,10 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
@@ -3276,65 +3278,65 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-spill": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.1.tgz",
-      "integrity": "sha512-PK1A1YxQVgisWacljbHAyL2z3MGXE+GWeXzNf2hHElzmtAkv412a3TXtMTL5XLZ1m0laLZxstEcf8L+S4zxvPQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.1-rc.2.tgz",
+      "integrity": "sha512-iayBN51zRj0+ER6KKJM6UlN1dfKXe5eDJeSwYmH+j3wLbCBQTD7Axnhmo9t68JBRrg+eczg2epFMR5RrXrisUQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-YquagM4ZY6p1+03BSJxfp/rK9yy/ZkfZ0yNumiL5juF0drte6OqUj6YvrR2/RVhV88Id85fv6ik0As70x9l+Ww==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-I2t9BRjFw33Ya7c/nSZEwZeDSOCk06fDnGvTmXZoaP+Y4mWRBKStfRk4DvBsUQJW+/ov/E5OEvhNhzhZcUnXgw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-spill-policy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-shbTUw8Cpq+X5XZlM3G8q5pPDmXnNgyW8NRDUg2l/bPLipdejIivs7T5dLLXKRtxhaD9GB6Z7jqFuy+dlV8iIg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ulkAuhjIm9sOzNdZ7TDqXyvk601Wn3mN/d1QkBBNmCnxt8yQY/nS4ixGtqCVWCu/tdzQOlVw55qKrcNvsQAJ0A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.1.tgz",
-      "integrity": "sha512-22Hg7hTTbr5fBYRXJ+5O3aBSHHfBLw7jKAPFWjp4HYziG6xXbnIa93QqgaNxz4rdpjTN9ihPP5Rc/zef+HwKOA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ptJ1ss8spF+Y2VXjsMV37Qh1+hviYWZylDvXtfEBXjLbPi/BP3dktT4B6OMIAD1rRN+0A4HdTqJBgLk7Gp1rig==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.1.tgz",
-      "integrity": "sha512-7p5qTSxunIQzzKOq1mVIwGh/USHuSuphHEHx3TTu6c+4Iumd6njZ4ijLsw4QrHDUhlGxWaTy9d9Ga/x6Wu4mAA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.2.tgz",
+      "integrity": "sha512-9/3OuaZpxf9NZWhrARpgZ7UBa03pPaTIiDBw+SfESfwVk42NNLVCQgvnEbrWoNwdtzmv0aYCEV23sKwwlQ0LBA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3342,49 +3344,49 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-storage-json": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.1.tgz",
-      "integrity": "sha512-MopZ2No4pWKV00BRQjBuGzaphx3YuNxQ4dCKF8ktDkGYdw/SOEjsurl2ejr2YoXUSLTPWpImEquhkOdRWDqAeg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.1-rc.2.tgz",
+      "integrity": "sha512-UNq6yn/iCh6T1TJ+4XN1Gofam3oqqNgENxAcnajRaD8KIsryVstS7Nke+j3vLdu6MDiGjCsilxyZYtqduE+Dog==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-MhsAoQc0KFvZyNzEsnrWRX1DwMlgPZ6KeTRUPdMwfpqmCcLgNmz36dl2OdiuUr71kbQyeF6HHO06EvrGhH1Qhg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-CNa0WuFCR69TMnBKYQInz49/olDSaVHiYkDTyTuDh7YW7Y80/f/HjQe5G0fQaqZMLla3IUSXCIPl5EssWmjcQw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/dsh-agent-presets": {
@@ -3414,68 +3416,68 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.1.tgz",
-      "integrity": "sha512-UHuipiCfXPHrdcwy+Ck+2BzzW4l9IH5HsiWDDVrURsIvCaceFq6jWlaR1Fv3/1iylEl8FmOS3u5fHlLrBYo9qQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.1-rc.2.tgz",
+      "integrity": "sha512-m5qWHamlJqpwJEUZIZHfKEERhCmsR74B93jGo9ues2pMB7yYjk297oRLQXmaJrQi9FD6zmFntgpwXStK20mbWQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.1.tgz",
-      "integrity": "sha512-zp3HCvf8EPz6Ey0tD0d9+q6FeA0eVTvlBo3+N6m21+SrF8fp47Fb6kFgJ9zoBh4vNGXZ7bDZ/LOhYg4TlotBQg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.1-rc.2.tgz",
+      "integrity": "sha512-+GCNjPnRJOB4fv6pc4b9qQZvzoluH9neOLCrKEpJsoNn1c2XCQMaylc8G+WEziIbvzDvHcpKJJWm50XlKuDfMg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.1.tgz",
-      "integrity": "sha512-KPC3gU/gc2Oxh0pdzOL3Y1czTeZLu34jJo0YVaFFToQweiDwCUL/6nBLWq3S7nEiDL73hTG+u2lca1/ShaWg+g==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Xxe9GzhOK4gIfNUG/Wgx3vsCx7aGZTt268943aRO0wlKQ7Jcku5rH84KfJ+IP2ZY0954KRm4+GQLOKJc/1SSjw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.1.tgz",
-      "integrity": "sha512-SXd/WT2SddMYUhCno518bmOdv6SqH9OX4X/u2uVzgT793UJ1bNtx5UZiTIox3jZFZXeSj+snthuzCiZfnA2j+A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YXEBaUfdkCJm4Wj/w08imS+1TMd3K4Rjr/xD5tuJR1I4/EnBCseP6AOlwjcrDP5PPWfOZghrK8H01sk6cqiK8Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.1.tgz",
-      "integrity": "sha512-y3omlRw0rE8v9VrSp+QQwzVca7fXp6UbSuW0klsYsC9QxEMx6iOSXsZyu8ZKLwd2hh38uY8GspzB8oTdXqpiHQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.1-rc.2.tgz",
+      "integrity": "sha512-I4pyzpohZEVRQQbuEpMP0t8oKsf+XIlRo64aJVKGXI2eMcg9f9gbfhKQNYNqRGbegQL1HYpSLU6Rzyibldgwaw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3484,104 +3486,104 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.1.tgz",
-      "integrity": "sha512-YILPMh2sfwhcK1ijr9ll7TKVQPwhhfrxIFl/Kdi+LIeLiTlOOnt6krpGnlXfzRPu7SzpNnwcetKljKOrHtY2YQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.2.tgz",
+      "integrity": "sha512-on4hjAlYI5uX9q7Sf95YkMMBVe6heywtA/H50ksrIMUub8U2B98hO9iQpHhjwIO1F1vu+5pLcPvRr6yUGGmtXQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.1.tgz",
-      "integrity": "sha512-34Ef13Gt5NG+W+u5Z41tt/TPBNFwMfjXBCy3ySSpZw/8b6KXDs2KwgLtrfBBBOSB9wV8ONtC5DCCEsOvRr+u9A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.1-rc.2.tgz",
+      "integrity": "sha512-NOsajXg4cX09coiLtCMgSqXAw90uptqyA9Njv6MVAOLgh6ctpjsolL3VIIWapSJ6AngsCTqVXW7sxexwpl0yUw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.1.tgz",
-      "integrity": "sha512-m9ADv/ZAMI1uubj3zihD1G67Ql2pzrc5HeOUPx32Iwq8autKqj5/Jef8QnbUgQsqNAlLHodhuLroTJbKPv42+A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ltR4K6OBe/7I04w4gCGgbxIv8/qVYHO13vAvwfwmrDM5jePbrEPMu5/xpwPbR28C0kOb7dQy2Z1+FwtVGxviqg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-time-context": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.1.tgz",
-      "integrity": "sha512-MIk6ID6LDDaP0NstVY0D36+qIzB1X35fC85PXsTr/b8g9ccu4GVod6ohunnhD6RcHQ76qHtVcKhtu+AoiFpebQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.1-rc.2.tgz",
+      "integrity": "sha512-4Q1sCr06SfJ7jkhrvfdg8ZSFp5Ohtl4E9nH19nUbIjcGK8F5yA2h68HPEglztDo54vxI5HZSblLIjdGKZkY+FQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.1.tgz",
-      "integrity": "sha512-9JURjw8lFbSAQogQiN7KvNAJc7WdUMdrj1PkcZEs3y0rMuTb4Z0+l0QS628+BzmKzB2ndZs8QO8VJSMTSdpaIQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.2.tgz",
+      "integrity": "sha512-RrouVgU3G5gXr9zHhpThkMG6YKdcRJzXXdPm1dq3ioBxbvxlfMSfNY4tN8lWMJxLyGtvWkPra0HQX+YWxvdOOA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tmux-context": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.1.tgz",
-      "integrity": "sha512-KvAviVyFybH1Gh08PLBDMV2VFUqVy1Pf1w8I8tI/EyiuHiZ3R8WXfYs4qp/oGN+n/atCHmJwkicR67xpG3LHFQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.1-rc.2.tgz",
+      "integrity": "sha512-gsOY/pbm9gdO2sKlqWymv4UxGocm3/4hU+84eTD/Wi6Vnt0QOPDSHEO/SjZ/sdIxiTxoKQLz4mqy0LYmc7DNDA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-token-meter": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.1.tgz",
-      "integrity": "sha512-P5CIwXRbGUO8AquJIuoZaLlBY7NZ/OqGM7BRM9Qps+vNaC3lmwa/Dq/I+fhmckXjPMYLA20X4kVVn/SDUG422Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.1-rc.2.tgz",
+      "integrity": "sha512-XHSgvMga4h73LHzuG8gztocs74+6NYg7ciHdu2aM2PYC59/rPfxq4Kz9Hq6TTvYa4a/sDgCij/T0tZBNvQixDQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3589,100 +3591,100 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.1.tgz",
-      "integrity": "sha512-MUXpZ6BYy/rAY8Yp+NXXwbH9Cxlria4GGq+nbnYaTHpc8xM76X1hpp3n2iOzV/ef9V+IDCWmW3Z3gnljbDFWRw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.1-rc.2.tgz",
+      "integrity": "sha512-6zSUxSducAdrSJ9J172rzJrqv0I/LbZQZa2ri3k0shYzM2reOi1tf+xWDxVFafUscxeyBpnpmNfXXBuZPt0HZw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.1.tgz",
-      "integrity": "sha512-e083Qn7V8oESrvMU+7oC7wpj16PgU8/fXErgEsSyxFIY8e5qU/+K1jWX1B2SvVS/bpE7+nm3Lq2jNDFpXZ6+Sw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YNmrKmBanj5EQn1zejjbo4UUFtg2/h3s9y0lY3vBu+dezNz4HdUlSkSZACbNUAZywyLomdhlt4rJdtdnrqyS7Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-nbEyHaldIFH0XSZwGGqTL5TC9Rw8EsdN/Yy3ONxu4Leo6evMP0FhwND2zOD2ORTrp5R2lqLaLWcz2c3RZWF8Nw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-pPI2ln6OdlCW6Kks5VWsFm7sC5NEkZetKOJ8TUrsXkbCM32wWLEaMPVsN9p5XcG/ao99p+Nh0Rdx7PYn4lfg0g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.1.tgz",
-      "integrity": "sha512-lAd+eRth7mhr/SRb8CFz9OhS5arF3VQgnrWxfeftE+oofytj8juiwppSBXPfjl1lP6a2D5jVsQ0G6pd3pdZCXQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.1-rc.2.tgz",
+      "integrity": "sha512-vPYSRvYV9mDSNRl3BU4M76cIA4oigBD16eS/TxFjAj6fpkdc4JgLA9nsvl515/1DJLEIYnp3HQF3iCsptEdurw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.1.tgz",
-      "integrity": "sha512-NvBKLiR/mqLP+pLulayPH8t1bmOYFGoUGUR/V5hUP4GjUpS7sCrR+PH519N0lSRgxghx9Q1YrvC05M2wcfV5vQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.1-rc.2.tgz",
+      "integrity": "sha512-cBgfa+0Al94/ur+jaWk2uHZ2ChFw3Mf9nmgaFcToFxkBDAcSCpeKjXK27aw/g2EIz3MvPMzOJo9MLDF3WkUEZg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.1.tgz",
-      "integrity": "sha512-T9teZZdjshbc/J+nsQV7o6Jdp+q/A8tYSx3FHP5BbN14T8tlyd9F7FWccicyNe4uni3e6ZlUfXjE3Qx6c1epGA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.1-rc.2.tgz",
+      "integrity": "sha512-llX8AWbaI3CGme/a2eeTSfy5atk8u3iJeOFzmZV/KZ0v0hMhKZIK1xQInWwC9OmSDJ/StStJe0hDPVLWbB7hVg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3690,22 +3692,22 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.1.tgz",
-      "integrity": "sha512-aMSfkvvrvXI7uLcLb06J+WR+ZjdAD7ROswC3g/l4lpMV7h8WuRcEp5uCpdxuMrgQ6bqNrpDD5QT/KDU8d7VE3A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.1-rc.2.tgz",
+      "integrity": "sha512-gHu+6Cs9zs1EYd5KSEJxAsw29sz8pGaj+wJb1cwbK39gzK0AUQ10RlBYuxee6SXgMMnD/vFJZFjxRtCAdo1CCA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3713,202 +3715,202 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-spill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-goal": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.1.tgz",
-      "integrity": "sha512-3SRUmWx3Q7TYlg3ySDiWII58Df6RivxkF2OHQUxJRpjHboJJsoO2YwOAFFoaNij92OHvXKhB914w/FKbIVqz4Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.1-rc.2.tgz",
+      "integrity": "sha512-kTECpE732uwlxRJr/jBZb1BqaxZzrA7Rv4KuM3eolvhoTJ5zjyiR2YHmDmCSfuI6zmA/BEfWss7D0mLbVtJEZA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.1.tgz",
-      "integrity": "sha512-yW+4977eNR/ZjYlEMhA2XgY6pFR+Rj8DBoZV4bG+NKWGWXec2gxML4UzdC/EVg5qJ/b08P07/3MpdjfEBCs6Uw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.1-rc.2.tgz",
+      "integrity": "sha512-wCU7mo2uoQcAtz7de4ZXP2es9lALsmz6XzC+KAlS2e7/yTBi9a5LL2vdSr6XhExVAuhu/6f9eM/w4EQBOxtKlw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.1.tgz",
-      "integrity": "sha512-dyKAw1z960cfqIMaZwXSCDY4LIZ9w7RlWxBcanVtCNXUzqac8qCVvYNoXGnJ5u9KTjdfYyxp9uAmlvdQIoe9eA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Gr0F4VWCIIR25qWVv4mMEJnewXILHLCkZwrLfbHA2OOI7DNvvdB5wjJxhuo+ZQa8/3KJ/byQGtEBqCY9mb10Zg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-9+LWvtD5fucgNF2QzJJgFFcBHa/hvtQvPqGy+N31w2BE2lXogtFZBwWRdfH1L4Fye3F0+37l88xs3coZY4RONA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-h/CgOw+pZQDl+upWeFdUF1wzgZQ4NgTSMAmlOe60QRObEP8rEYggELP3QQiJbgXs34N5E6Ovf4W/ADtnFJVsEw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.1.tgz",
-      "integrity": "sha512-qJMzBfmljqpm1BiedNwdfBnuvWH3+5N2duC/x1hGA3IodHQ1Rc03hVtWJnbB6GYctshJbLRft7yLnNTO6ghgNw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SGOMIJPufjz+eia6p8lRIZ9ybflk/6m1E+MAm6zg4QeCnXcGr2z3fkA8+/CTViosj9wh8NfXJYMFweRpbigkDA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-skill": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.1.tgz",
-      "integrity": "sha512-1VDrgqj3I+I+LmqD+B1RTb0zU7uZuajjPmczCNQAV0zuLjTIbwiHne7G4gIxm5CE7uXlxsSzZnF7ZSuYKF1m/A==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ADOjLELlf6QgrJDFdieNDN42pInPHL39ZU/+v+MXxkhE6poM+kcZmn/eCxbfSvMBFQm9E58Zvg60c0hrsi5BCg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.1.tgz",
-      "integrity": "sha512-4P4SKqMUeEq39Dcw7oXenIMKlkyp3lwvchnmP9shf/fRAs5nAxDPMja4Wb7sEXQkVaBF9pUUp7GZPhfqhFIGWQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Pzyjfr3T9VSUKyAmxoejp4GVvwup9gmj2Kx6WmoUEMK17NPZrhRXgMXbzFu2JnRjxRp2p1FSs4JDb2734xMQzA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-fs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-fs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.1.tgz",
-      "integrity": "sha512-N2FSHL+IsjBUTKsOeVuu4IrERuLJ32h8Zp5TWWQ7ONy+yISnFZqkmGrx6BB55HsnM4OM1fzVcBME7+tVqQ1tdg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.1-rc.2.tgz",
+      "integrity": "sha512-26TuzAuxy8x/jDuWJdvCSRQ/ojm7++5FQ6CRLCdZcgU/3Iw2ZY9TKqAIz48cFHOv/wS3+ru0rX3fF1etv6a11Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.1.tgz",
-      "integrity": "sha512-3Y4G1s4ebdAwln41Jike3Rnp4k4d/v47PQVFlk9hVJvbrt2C6LGLM1Id2C4+30Hi6JPE4EaO3wIutkX5ar4aLw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.1-rc.2.tgz",
+      "integrity": "sha512-I1enWV1Pm045l5usFwpJtbzJEpic/XdPdWOg+l0it4ia1jUq9l5jPZeQ85Z2x4UbyxtXFOMDGvSL+9kMi0LzLQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-subagent-report": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.1.tgz",
-      "integrity": "sha512-TbtTJEZcE0K3UU7tbkgpTy3T6bJrn3SGyzpSiguiPkqYSh2i3qi4kHKMgI2fH5NlmznyKI2EmWb9Tjw53zxgQw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-subagent-report/-/dsh-tool-subagent-report-0.1.1-rc.2.tgz",
+      "integrity": "sha512-nxy8Y4PhhaasMewLb/Cj+gU/CthtXgtrPuR2NZmYr49xWYXBu8A2IoWFwf6Y7HkbZRSPg6LPsQJEpftjnIYc2g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-todo": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.1.tgz",
-      "integrity": "sha512-j3gZX+p1vJYrJpPFaXiyYSEQf8rpWbQ7sNJASRCFR2Q3a3rGHXrcFVr4A7WXH7zgIHwcNKK4FHv7aDAk2JuMrQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YKP77X/fiKxva/ZzcqkDy6WhNUWYA9oTrAPLAVf3GP+ubIu+r4/cPxu6f2+/8rXLYSi47HXAHajeqQbw2UNXnQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3916,17 +3918,17 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-web": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.1.tgz",
-      "integrity": "sha512-d3/9NJQc2Vcv4m6Q94POCRZ0conqjAeqUobNwIpMiWrSL4U8jZYzXwFVBw0Sw+cwYVBi2Og5Vv9aJmWANTX3Mw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.1-rc.2.tgz",
+      "integrity": "sha512-oV54OJFYYseJCT77F8lr9ZU/f/x8ZbPTmgQpYPC/O24Hw5uqUHEADkukC2ajrltZSTd0+OVqxHFwpWH4gjDoHQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -3935,56 +3937,56 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.1.tgz",
-      "integrity": "sha512-KS7BF1W6fGFgatMQ7daCRxSDH3zG14ob3s2b0Qzb0chZAIbxVe/DcQi2xTcK0MpXr77RKikdHUgU6n/+arC+pw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.1-rc.2.tgz",
+      "integrity": "sha512-tOLaym8/eyHOATADljSbUYBizaYZTqMKp8p+r2SwiWqIjnRral67BwoO5boX+3t+m2Z45+mvrEnHCu1deYLuaA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.1.tgz",
-      "integrity": "sha512-vvb7G/DR/guhL1B5pMRdmi44YQedeefp02Q6pkHS+MgjNl8N//CZFCPSxSX9kX/a8R5/tDQZxxGsZdj6vcC6zA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.2.tgz",
+      "integrity": "sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-loader": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.1.tgz",
-      "integrity": "sha512-8NKYGmopkroNhPtMbTc1Xdx5twz8VxlV1fVie22LgxmS5c8eP2Q5DQc8jV5A/5tePYchsC+FpeNSPMKUgzkO4Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YTShO0kcBBwXDx8J1Xgn0z4l9nNBqBbpHh2wFAN+PXPORXn0p0F4RY5z2YUVLKLJaL8XRjNKdl43hHK/ttomqw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -3992,151 +3994,151 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.1.tgz",
-      "integrity": "sha512-bdPYdYDNYgTGgEkHCIEB/QUUTXo0r5hkEyWlh+v95Qe34B0ZO3KhYTPSPaoYDwP0kEaOwtmmxNGZd8HFJ8VQnA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.2.tgz",
+      "integrity": "sha512-lxBssDc5Pz1qBE5kuIyaArA7AvIPq9rpaVclylodiSzVJe95e2xruBg73tflyjtd8y00toet+DLgQ6tSSsq6Kw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.1.tgz",
-      "integrity": "sha512-9kavDx4n2dxtDNU8uPpoaB604uVBST2aA0TvcR5d+GTA7/vFgqmT2JjQv5PG+GwM+JAO08MsP2ldWMB+FPo/Zg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.2.tgz",
+      "integrity": "sha512-ATZu3i7UId+ktsWW3pUFm5Hi1fVsRXFmByATVPp2RlxH1zjxXnauVW6k70ZwU/4FOsphRzo65SXOlAXA+natYg==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.1.tgz",
-      "integrity": "sha512-r2TkC0JJGQ8EOyTH8DXafbcj080NdNbVzoNERA1pRTrH7+ZE0PHU6MZU7xGy7cwAKmAUGnm1DjF8UHOQN6ns2Q==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.2.tgz",
+      "integrity": "sha512-SdsO4Rs+NeJFoertkVilXBACREOLfkKPJJznYKqDhJxeRo38RJ56dtj0Xd0/6rERmsQiMck4Bwdrzg1ubUqPNA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.1.tgz",
-      "integrity": "sha512-q5RZczXTNzSC/fas+qIno5jCqH/jotz0OpBzRCTNMPV1ID4YcGroaUKsLxzaGXP5bbiaVlX5Tqt5FUYO6rYStQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.2.tgz",
+      "integrity": "sha512-9lYoB7qCFE+Vvgwjny3MnRfS7QUefOspj4KpE3b30DAAJfxwrU4hRtLCHOKxyurF01qrkoEBBpXn4H5ilXYTKg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-web": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.1.tgz",
-      "integrity": "sha512-fYJ3epKwpY0zO61a9SshY/gKmrcfP7N9EX7/VUGWdpE89jKg52LkioZ5QQ2cKYatbPUHLWx3H+llCGmqOf4bAA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.1-rc.2.tgz",
+      "integrity": "sha512-Rtikc8RUlfx6m9+hYvKB3JlAD34PrI2UFHEu1h8UMb7pM/ulIRpjBF7TPlg537WRK4ufCysqCJm0RheNMoYCcQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.1.tgz",
-      "integrity": "sha512-qV0Djh/9lhdBMlkwry8x3Fu3pckiNur8OiQN8cIRvGqyDrJ3yWBjJYga491OeFEmCw/QF9DbfKgmU/O8r4gzlg==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.1-rc.2.tgz",
+      "integrity": "sha512-1zGHY7qwBVlVJrzIWu+86SuBZXaVUxe2JRfffsuRvKXq2QcR/K4CoJJfZ43cDoWKu9xPvvxz7w2ezV+EdXgg1A==",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.1",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-app-boot": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-modules": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cmdline": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-stats": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage-json": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
         "@deepseek-ai/schemastery": "^3.18.1",
         "commander": "^15.0.0",
         "open": "^11.0.0"
@@ -4144,9 +4146,9 @@
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-web-app/node_modules/commander": {
@@ -4207,81 +4209,81 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-web-frontend": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.1.tgz",
-      "integrity": "sha512-LxKEcBy6npgLXqrg1utA4/OZocXrx1tTQaIK1VH1l2vNs0vN6fOKSMpbvbUB0mW0RKxXmHg8NfJ4JkdliMtIsw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.1-rc.2.tgz",
+      "integrity": "sha512-1cjf39g6RW7cgtvwhIF6MSnp5sk3KYRkmRhZM4GETWLXCrTfMD0WCJr3yME1uvJsYPTk28XmKXwwMUPrO3kksQ==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.1.tgz",
-      "integrity": "sha512-3iQHtGsPYEi0r2Zd34XO+FayTPrE9PfPpwnHSdvKy0MdfGqjEvJyujh0V4X9tA8EhW1eGXzoOXIIKzVOxxdmTw==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.1-rc.2.tgz",
+      "integrity": "sha512-g8wl7k0Htd0MI5CCh0XHK768P5u05ge0JRThMSgNYQvuKJ+gY4uVwzPXJb7eZ7xNWgXt8ERLXIOMVRylaJX1XQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-web": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.1.tgz",
-      "integrity": "sha512-Q7Vq+oqklhlM9XeQp+LmOZDWXCvxSQHdFjY1p5DxUOgJgLCcoNe+0QsOwH7VHm99ZfTtGisH/t7oWx+m7fbcHA==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.1-rc.2.tgz",
+      "integrity": "sha512-YHUGOBfHGXVr9RRAdCvKZ/1SeeKx4jRumSBMNJo1ETbVqEK+ov2kV61pHFfLu1h+heCsEbOsEJeVXvgYC8EBhw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.1.tgz",
-      "integrity": "sha512-i569BFPdkc7OU/kfcJvRH59GGz9wXmUR5pc6pPVZLNkpPvaqiOgThnK3D4wSfq9SkxuzK4026IwITsUJF2poig==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.1-rc.2.tgz",
+      "integrity": "sha512-DdMO6gn56wakPTetkLKwuuj7cI3y3ji6c0oR3ksFQLhkYwaYV1hZSxVU6HEiW3hl2so8C163ms8QBgDyIWZsXg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.1-rc.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.1.tgz",
-      "integrity": "sha512-rdw8ovh2C3DlE1UyQUUFv+U5b0JoNveypWlldslEjkwLQTO8zKeZE0HGPEGnIwHPz3wYOr/jQKe+mbKnFQ94nQ==",
+      "version": "0.1.1-rc.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.2.tgz",
+      "integrity": "sha512-jBUob4H5TZAiExq9YNVCglKAFmAKMtd1UbyqFfnZZ1Owm+3c3NbAXY947MHiD6NwCwFEW1y7FjrFj66UQvG90A==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.1",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
-    "@deepseek-ai/dsh": "^0.1.1-rc.1",
+    "@deepseek-ai/dsh": "^0.1.1-rc.2",
     "dompurify": "3.4.13",
     "markdown-it": "15.0.0",
     "node": "22.22.3",
@@ -233,7 +233,7 @@
   },
   "allowScripts": {
     "node@22.22.3": true,
-    "@deepseek-ai/dsh-subprocess-local@0.1.1-rc.1": true,
+    "@deepseek-ai/dsh-subprocess-local@0.1.1-rc.2": true,
     "esbuild@0.25.12": true,
     "node-pty@1.2.0-beta.15": true,
     "koffi@3.1.5": true,

--- a/scripts/patch-dsh-llm-pi-ai.mjs
+++ b/scripts/patch-dsh-llm-pi-ai.mjs
@@ -7,7 +7,9 @@ const packageJsonPath = require.resolve('@deepseek-ai/dsh-llm-pi-ai/package.json
 const packageRoot = dirname(packageJsonPath)
 const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
 
-if (packageJson.version !== '0.1.1-rc.1') {
+const SUPPORTED_VERSIONS = ['0.1.1-rc.1', '0.1.1-rc.2']
+
+if (!SUPPORTED_VERSIONS.includes(packageJson.version)) {
   throw new Error(
     `Unsupported @deepseek-ai/dsh-llm-pi-ai version ${packageJson.version}; `
       + 'review whether the tool replay and connection probing patches are still required.',
@@ -19,15 +21,16 @@ async function patchFile(relativePath, replacements) {
   let source = await readFile(path, 'utf8')
   let changed = false
 
-  for (const { before, after, label } of replacements) {
-    if (source.includes(after)) continue
-    const occurrences = source.split(before).length - 1
-    if (occurrences !== 1) {
+  for (const { candidates, label } of replacements) {
+    if (candidates.some(({ after }) => source.includes(after))) continue
+    const matches = candidates.filter(({ before }) => source.split(before).length - 1 === 1)
+    if (matches.length !== 1) {
       throw new Error(
-        `Cannot apply ${label} to ${relativePath}: expected one matching source block, found ${occurrences}.`,
+        `Cannot apply ${label} to ${relativePath}: expected one matching source block across `
+          + `${candidates.length} candidate(s), found ${matches.length}.`,
       )
     }
-    source = source.replace(before, after)
+    source = source.replace(matches[0].before, matches[0].after)
     changed = true
   }
 
@@ -35,12 +38,11 @@ async function patchFile(relativePath, replacements) {
   return changed
 }
 
-const runtimeChanged = await patchFile('lib/index.js', [
-  {
-    label: 'cross-provider DeepSeek tool replay',
-    before: `\t\t\t\tconst context = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade, profile.maxRequestImageBytes);
-\t\t\t\tconst iterator = toStreamChunks(snapshot.models.streamSimple(model, context, {`,
-    after: `\t\t\t\tconst rawContext = attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade, profile.maxRequestImageBytes);
+// DeepSeek-compatible relays require reasoning_content to be replayed on
+// every assistant tool call. pi-ai normally strips thinking signatures when
+// provider ids differ, so normalize only those tool-call messages to the
+// current DeepSeek wire identity before dispatch.
+const toolReplayNormalization = `
 \t\t\t\t// DeepSeek-compatible relays require reasoning_content to be replayed on
 \t\t\t\t// every assistant tool call. pi-ai normally strips thinking signatures
 \t\t\t\t// when provider ids differ, so normalize only those tool-call messages
@@ -58,17 +60,38 @@ const runtimeChanged = await patchFile('lib/index.js', [
 \t\t\t\t\t\treturn { ...message, api: model.api, provider: model.provider, model: model.id, content };
 \t\t\t\t\t})
 \t\t\t\t} : rawContext;
-\t\t\t\tconst iterator = toStreamChunks(snapshot.models.streamSimple(model, context, {`,
+`
+
+// 0.1.1-rc.1 calls toPiContext in one line; 0.1.1-rc.2 spreads options with
+// the watchdog signal and passes the route's image policy.
+const RC1_CONTEXT_CALL = 'attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext(options, attachments, onReplayDegrade, profile.maxRequestImageBytes);'
+const RC2_CONTEXT_CALL = `attachments === void 0 ? toPiContext(options, void 0, onReplayDegrade) : await toPiContext({
+\t\t\t\t\t...options,
+\t\t\t\t\tsignal: watchdog.signal
+\t\t\t\t}, attachments, onReplayDegrade, profile.maxRequestImageBytes, {
+\t\t\t\t\tmaxPixels: profile.requestImagePixelBudget,
+\t\t\t\t\tmaxBytes: profile.requestImageMaxBytes
+\t\t\t\t});`
+
+const runtimeChanged = await patchFile('lib/index.js', [
+  {
+    label: 'cross-provider DeepSeek tool replay',
+    candidates: [RC2_CONTEXT_CALL, RC1_CONTEXT_CALL].map((call) => ({
+      before: `\t\t\t\tconst context = ${call}\n\t\t\t\tconst iterator = toStreamChunks(snapshot.models.streamSimple(model, context, {`,
+      after: `\t\t\t\tconst rawContext = ${call}${toolReplayNormalization}\t\t\t\tconst iterator = toStreamChunks(snapshot.models.streamSimple(model, context, {`,
+    })),
   },
   {
     label: 'explicit endpoint connection probe',
-    before: `\tif (request.provider !== void 0) {
+    candidates: [{
+      before: `\tif (request.provider !== void 0) {
 \t\tconst installed = catalogModels(request.provider);`,
-    after: `\t// A provider-only discovery is a catalog lookup. Supplying baseURL is an
+      after: `\t// A provider-only discovery is a catalog lookup. Supplying baseURL is an
 \t// explicit connection probe: reach the endpoint and let storedApiKey resolve
 \t// the route's write-only credential instead of returning a cached catalog.
 \tif (request.provider !== void 0 && request.baseURL === void 0) {
 \t\tconst installed = catalogModels(request.provider);`,
+    }],
   },
 ])
 

--- a/test/profile-scope-prune.test.ts
+++ b/test/profile-scope-prune.test.ts
@@ -31,7 +31,7 @@ describe('pruneShadowedRuntimePackages', () => {
   it('removes profile copies whose version differs from the bundled runtime', async () => {
     const { profileScope, bundledScope } = await setup()
     await plantPackage(profileScope, 'dsh-llm-deepseek', '0.1.0-rc.6')
-    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.2')
     const lines: string[] = []
 
     const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, (line) => lines.push(line))
@@ -43,14 +43,14 @@ describe('pruneShadowedRuntimePackages', () => {
 
   it('keeps profile copies that match the bundled version or have no bundled counterpart', async () => {
     const { profileScope, bundledScope } = await setup()
-    await plantPackage(profileScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
-    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    await plantPackage(profileScope, 'dsh-llm-deepseek', '0.1.1-rc.2')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.2')
     await plantPackage(profileScope, 'dsh-profile-only-plugin', '9.9.9')
 
     const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, () => {})
 
     expect(removed).toEqual([])
-    await expect(readVersion(profileScope, 'dsh-llm-deepseek')).resolves.toBe('0.1.1-rc.1')
+    await expect(readVersion(profileScope, 'dsh-llm-deepseek')).resolves.toBe('0.1.1-rc.2')
     await expect(readVersion(profileScope, 'dsh-profile-only-plugin')).resolves.toBe('9.9.9')
   })
 
@@ -65,7 +65,7 @@ describe('pruneShadowedRuntimePackages', () => {
     const broken = path.join(profileScope, 'dsh-llm-deepseek')
     await mkdir(broken, { recursive: true })
     await writeFile(path.join(broken, 'package.json'), 'not json')
-    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.1')
+    await plantPackage(bundledScope, 'dsh-llm-deepseek', '0.1.1-rc.2')
 
     const removed = await pruneShadowedRuntimePackages(profileScope, bundledScope, () => {})
 


### PR DESCRIPTION
## Summary
- bump the bundled runtime to `@deepseek-ai/dsh@0.1.1-rc.2` (now `latest` on npm)
- the patch script now accepts both 0.1.1-rc.1 and 0.1.1-rc.2 (`SUPPORTED_VERSIONS`), and the cross-provider tool-replay hunk carries both source shapes as candidates — older rc.1 installs still patch cleanly
- rc.2 restores `contextWindow` supply through the new `LlmAdapter.prepareCall()` seam (prepared calls now carry `modelInfo`), which the context ring depends on, and degrades images to text placeholders for text-only models instead of failing the turn

## Test plan
- `npm run check-types`, `npm run lint`, `npm test` (141 passed), `npm run compile`
- patch script exercised against both rc.1 and rc.2 sources (each hits its candidate; reruns are idempotent)