### PR TITLE
fix: send the required images field with commands/execute

### DIFF
--- a/src/gateway/node-gateway-client.ts
+++ b/src/gateway/node-gateway-client.ts
@@ -61,7 +61,10 @@ export class NodeGatewayClient extends AbstractApiClient {
   /** Executes one registered Host slash command without sending it to the LLM. */
   async executeCommand(sessionId: string, line: string): Promise<HostCommandExecution | undefined> {
     return this.callUnaryRaw<HostCommandExecution | undefined>('commands/execute', {
-      args: { agentId: sessionId, line },
+      // The typert descriptor declares `images` as a required strict field
+      // since dsh 0.1.1; host commands carry no attachments, so send an
+      // explicit empty list instead of omitting it.
+      args: { agentId: sessionId, line, images: [] },
     })
   }
 

--- a/test/node-gateway-client.test.ts
+++ b/test/node-gateway-client.test.ts
@@ -44,7 +44,7 @@ describe('NodeGatewayClient Remote carrier', () => {
     await expect(client.executeCommand('session-1', '/plan')).resolves.toMatchObject({ commandId: 'cmd-1' })
     expect(requests).toEqual([
       expect.objectContaining({ method: 'commands/list', payload: { args: { agentId: 'session-1' } } }),
-      expect.objectContaining({ method: 'commands/execute', payload: { args: { agentId: 'session-1', line: '/plan' } } }),
+      expect.objectContaining({ method: 'commands/execute', payload: { args: { agentId: 'session-1', line: '/plan', images: [] } } }),
     ])
   })
 


### PR DESCRIPTION
## Summary
Fixes `RPC commands/execute failed: ... args fields do not match the descriptor: missing "images"` on every host slash command (/permission, /model, /compact, ...).

The typert descriptor for `commands/execute` has declared `images` as a required strict field since dsh 0.1.1 (both rc.1 and rc.2), while the client only sent `agentId` and `line`. It now sends an explicit empty list.

Verified end-to-end against the bundled 0.1.1-rc.2 gateway: the old payload reproduces the exact reported error; with `images: []` the descriptor accepts the call (fails only with the expected session-not-found for a test id).

## Test plan
- `npm run check-types`, `npm test` (141 passed; gateway-client assertion updated)