### PR TITLE
fix: avoid duplicate clipboard image attachments on Windows

### DIFF
--- a/src/webview/chat/clipboard-images.ts
+++ b/src/webview/chat/clipboard-images.ts
@@ -1,0 +1,29 @@
+interface ClipboardImageData {
+  readonly items?: ArrayLike<DataTransferItem>
+  readonly files?: ArrayLike<File>
+}
+
+/**
+ * Returns one authoritative view of the images carried by a paste event.
+ * Chromium exposes clipboard files through both `items` and `files`; combining
+ * those views can turn one Windows clipboard image into two attachments when
+ * the separately materialized File objects have different metadata.
+ */
+export function clipboardImageFiles(clipboardData: ClipboardImageData): readonly File[] {
+  const itemFiles = clipboardData.items === undefined
+    ? []
+    : Array.from(clipboardData.items)
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((file) => file !== null)
+
+  return uniqueFiles(itemFiles.length > 0
+    ? itemFiles
+    : clipboardData.files === undefined
+      ? []
+      : Array.from(clipboardData.files).filter((file) => file.type.startsWith('image/')))
+}
+
+function uniqueFiles(files: readonly File[]): readonly File[] {
+  return [...new Map(files.map((file) => [`${file.name}:${file.size}:${file.lastModified}`, file])).values()]
+}

--- a/src/webview/chat/main.ts
+++ b/src/webview/chat/main.ts
@@ -37,6 +37,7 @@ import { closePermissionConfirm, closePermissionPopup, renderSessions, toggleArc
 import { isAtBottom, isNearBottom } from './utils.js'
 import { FULL_ACCESS_PERMISSION_ID } from '../../domain/permissions.js'
 import { closeTimeline, openTimeline } from './timeline.js'
+import { clipboardImageFiles } from './clipboard-images.js'
 
 // Streaming auto-follow yields to any reach for the scrollbar. A mouse-down
 // arms the interaction (drag intent before the first scroll event), wheel-up
@@ -234,16 +235,7 @@ document.addEventListener('paste', (event) => {
   if (!(target instanceof Node) || !elements.prompt.parentElement?.contains(target)) return
   const clipboardData = event.clipboardData
   if (!clipboardData) return
-  const itemFiles = clipboardData.items === undefined
-    ? []
-    : Array.from(clipboardData.items)
-      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
-      .map((item) => item.getAsFile())
-      .filter((file) => file !== undefined && file !== null)
-  const directFiles = clipboardData.files === undefined
-    ? []
-    : Array.from(clipboardData.files).filter((file) => file.type.startsWith('image/'))
-  const files = [...new Map([...itemFiles, ...directFiles].map((file) => [`${file.name}:${file.size}:${file.lastModified}`, file])).values()]
+  const files = clipboardImageFiles(clipboardData)
   if (files.length === 0) return
   event.preventDefault()
   void addPastedImages(files)

--- a/test/clipboard-images.test.ts
+++ b/test/clipboard-images.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { clipboardImageFiles } from '../src/webview/chat/clipboard-images.js'
+
+function imageFile(name: string, size: number, lastModified: number, type = 'image/png'): File {
+  return { name, size, lastModified, type } as File
+}
+
+function imageItem(file: File | null, type = 'image/png'): DataTransferItem {
+  return { kind: 'file', type, getAsFile: () => file } as DataTransferItem
+}
+
+describe('clipboardImageFiles', () => {
+  it('uses clipboard items as the authoritative source instead of duplicating their files view', () => {
+    const fromItem = imageFile('image.png', 1024, 100)
+    const fromFiles = imageFile('image.png', 1024, 101)
+
+    expect(clipboardImageFiles({
+      items: [imageItem(fromItem)],
+      files: [fromFiles],
+    })).toEqual([fromItem])
+  })
+
+  it('falls back to direct files when no readable image item is available', () => {
+    const direct = imageFile('image.png', 1024, 100)
+
+    expect(clipboardImageFiles({
+      items: [imageItem(null)],
+      files: [direct],
+    })).toEqual([direct])
+  })
+
+  it('preserves distinct images and removes exact duplicates within the selected source', () => {
+    const first = imageFile('first.png', 100, 1)
+    const duplicate = imageFile('first.png', 100, 1)
+    const second = imageFile('second.png', 200, 2)
+
+    expect(clipboardImageFiles({
+      items: [imageItem(first), imageItem(duplicate), imageItem(second)],
+      files: [],
+    })).toEqual([duplicate, second])
+  })
+
+  it('ignores non-image clipboard entries and files', () => {
+    const textFile = imageFile('notes.txt', 20, 1, 'text/plain')
+
+    expect(clipboardImageFiles({
+      items: [imageItem(textFile, 'text/plain')],
+      files: [textFile],
+    })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Treat `ClipboardEvent.clipboardData.items` as the authoritative image source.
- Fall back to `clipboardData.files` only when no readable image item is available.
- Add regression coverage for duplicate Chromium clipboard views, fallback behavior, deduplication, and non-image filtering.

## Why

On Windows, Chromium may expose one pasted image through both `clipboardData.items` and `clipboardData.files`. The workbench combined both views and deduplicated them by file metadata. When the separately materialized `File` objects had different metadata, a single Ctrl+V staged two image attachments.

## Testing

- Manual Windows Ctrl+V image-paste verification
- `npm run check-types`
- `npx vitest run` — 48 files, 312 tests passed
- `node esbuild.mjs`
- `npm run package` — win32-x64 VSIX packaged successfully