### PR TITLE
fix(gateway): persist approvals/questions across session switches and surface background notifications

### DIFF
--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -1,4 +1,10 @@
 {
+  "Switch to conversation": "切换至该会话",
+  "[gateway] Failed to switch session: {0}": "[gateway] 切换会话失败：{0}",
+  "Harness session \"{0}\" finished its turn.": "Harness 会话“{0}”已完成本轮。",
+  "Harness session \"{0}\" failed: {1}": "Harness 会话“{0}”失败：{1}",
+  "Harness session \"{0}\" requires approval for tool \"{1}\".": "Harness 会话“{0}”正在等待工具“{1}”的审批。",
+  "Harness session \"{0}\" is waiting for your answer.": "Harness 会话“{0}”正在等待您的回答。",
   "Configure DeepSeek API Key": "配置 DeepSeek API Key",
   "The API Key cannot be empty.": "API Key 不能为空。",
   "The key will be stored by the local Harness credential service.": "密钥将由本地 Harness 凭据服务保存。",

--- a/src/gateway/harness-gateway-service.ts
+++ b/src/gateway/harness-gateway-service.ts
@@ -69,11 +69,13 @@ interface PendingApprovalRecord extends PendingApprovalView {
   readonly clientId: string
   readonly eventId: string
   readonly approvalId: string
+  readonly sessionId?: string
 }
 
 interface PendingQuestionRecord extends PendingQuestionView {
   readonly clientId: string
   readonly eventId: string
+  readonly sessionId?: string
 }
 
 
@@ -393,8 +395,12 @@ export class HarnessGatewayService implements vscode.Disposable {
       skills: this.skills,
       jobs: this.jobs,
       queue: this.queue.map(queuedPromptView),
-      approvals: [...this.approvals.values()].map((pending) => ({ key: pending.key, toolName: pending.toolName, ...(pending.reason === undefined ? {} : { reason: pending.reason }) })),
-      questions: [...this.questions.values()].map((pending) => ({ key: pending.key, questions: pending.questions })),
+      approvals: [...this.approvals.values()]
+        .filter((pending) => pending.sessionId === undefined || pending.sessionId === this.activeSessionId)
+        .map((pending) => ({ key: pending.key, toolName: pending.toolName, ...(pending.reason === undefined ? {} : { reason: pending.reason }) })),
+      questions: [...this.questions.values()]
+        .filter((pending) => pending.sessionId === undefined || pending.sessionId === this.activeSessionId)
+        .map((pending) => ({ key: pending.key, questions: pending.questions })),
       subagentCount: this.subagentCount,
       subagents: this.subagents.map(subagentView),
       ...(this.subagentAddress === undefined ? {} : {
@@ -708,8 +714,6 @@ export class HarnessGatewayService implements vscode.Disposable {
     this.skills = []
     this.jobs = []
     this.queue = []
-    this.approvals.clear()
-    this.questions.clear()
     this.subagentCount = 0
     this.subagents = []
     this.projections = {}
@@ -1059,8 +1063,6 @@ export class HarnessGatewayService implements vscode.Disposable {
     this.subagents = list.entries
     this.subagentCount = list.entries.length
     this.projections = {}
-    this.approvals.clear()
-    this.questions.clear()
     this.fireChange()
   }
 
@@ -1558,6 +1560,25 @@ export class HarnessGatewayService implements vscode.Disposable {
       this.pendingQueue.release(sessionId)
       this.maybeAutoMergeWorktree(sessionId)
       this.metaStore.recordTurnChanges(sessionId, event, this.entries, sessionId === this.activeSessionId, (id) => this.summaries.has(id))
+      if (sessionId !== this.activeSessionId && event.data.reason.kind !== 'aborted') {
+        const title = this.sessionTitle(sessionId)
+        const actionLabel = vscode.l10n.t('Switch to conversation')
+        const isError = event.data.reason.kind === 'error'
+        const errorMsg = isError && 'error' in event.data.reason ? event.data.reason.error.message : ''
+        const message = isError
+          ? vscode.l10n.t('Harness session "{0}" failed: {1}', title, errorMsg)
+          : vscode.l10n.t('Harness session "{0}" finished its turn.', title)
+        const notify = isError ? vscode.window.showErrorMessage : vscode.window.showInformationMessage
+        void notify(message, actionLabel).then((action) => {
+          if (action === actionLabel) {
+            void this.openSession(sessionId)
+              .then(() => vscode.commands.executeCommand('deepseekHarness.chatView.focus'))
+              .catch((err: unknown) => {
+                this.output.appendLine(vscode.l10n.t('[gateway] Failed to switch session: {0}', errorMessage(err)))
+              })
+          }
+        })
+      }
     }
     this.fireChange()
   }
@@ -1598,6 +1619,12 @@ export class HarnessGatewayService implements vscode.Disposable {
       this.pendingQueue.dropForSession(removed)
       this.pendingQueue.forget(removed)
       this.metaStore.removeSession(removed)
+      for (const [key, pending] of this.approvals.entries()) {
+        if (pending.sessionId === removed) this.approvals.delete(key)
+      }
+      for (const [key, pending] of this.questions.entries()) {
+        if (pending.sessionId === removed) this.questions.delete(key)
+      }
     } else if (event === 'api-session/status') {
       const id = String(args[0] ?? '')
       const running = args[1] === true
@@ -1630,23 +1657,44 @@ export class HarnessGatewayService implements vscode.Disposable {
     readonly request: Record<string, unknown>
   }): void {
     const clientId = this.remoteEventClientId ?? ''
-    if (frame.event === 'approval/asked' && String(frame.request.sessionId ?? this.activeSessionId) === this.activeSessionId) {
+    if (frame.event === 'approval/asked') {
       const key = `approval:${frame.eventId}`
+      const sessionId = String(frame.request.sessionId ?? this.activeSessionId ?? '')
       this.approvals.set(key, {
         key,
         clientId,
         eventId: frame.eventId,
         approvalId: frame.eventId,
+        sessionId,
         toolName: typeof frame.request.toolName === 'string' ? frame.request.toolName : '',
         ...(typeof frame.request.reason === 'string' ? { reason: frame.request.reason } : {}),
       })
-    } else if (frame.event === 'question/asked' && String(frame.request.sessionId ?? this.activeSessionId) === this.activeSessionId) {
+      if (sessionId !== '' && sessionId !== this.activeSessionId) {
+        const title = this.sessionTitle(sessionId)
+        const actionLabel = vscode.l10n.t('Switch to conversation')
+        const toolName = typeof frame.request.toolName === 'string' ? frame.request.toolName : ''
+        void vscode.window.showWarningMessage(
+          vscode.l10n.t('Harness session "{0}" requires approval for tool "{1}".', title, toolName),
+          actionLabel,
+        ).then((action) => {
+          if (action === actionLabel) {
+            void this.openSession(sessionId)
+              .then(() => vscode.commands.executeCommand('deepseekHarness.chatView.focus'))
+              .catch((err: unknown) => {
+                this.output.appendLine(vscode.l10n.t('[gateway] Failed to switch session: {0}', errorMessage(err)))
+              })
+          }
+        })
+      }
+    } else if (frame.event === 'question/asked') {
       const key = `question:${frame.eventId}`
+      const sessionId = String(frame.request.sessionId ?? this.activeSessionId ?? '')
       const raw = Array.isArray(frame.request.questions) ? frame.request.questions : []
       this.questions.set(key, {
         key,
         clientId,
         eventId: frame.eventId,
+        sessionId,
         questions: raw.map((question) => {
           const record = question as Record<string, unknown>
           return {
@@ -1668,6 +1716,22 @@ export class HarnessGatewayService implements vscode.Disposable {
           }
         }),
       })
+      if (sessionId !== '' && sessionId !== this.activeSessionId) {
+        const title = this.sessionTitle(sessionId)
+        const actionLabel = vscode.l10n.t('Switch to conversation')
+        void vscode.window.showInformationMessage(
+          vscode.l10n.t('Harness session "{0}" is waiting for your answer.', title),
+          actionLabel,
+        ).then((action) => {
+          if (action === actionLabel) {
+            void this.openSession(sessionId)
+              .then(() => vscode.commands.executeCommand('deepseekHarness.chatView.focus'))
+              .catch((err: unknown) => {
+                this.output.appendLine(vscode.l10n.t('[gateway] Failed to switch session: {0}', errorMessage(err)))
+              })
+          }
+        })
+      }
     }
     this.fireChange()
   }
@@ -1789,6 +1853,12 @@ export class HarnessGatewayService implements vscode.Disposable {
   }
 
 
+
+  private sessionTitle(sessionId: string): string {
+    const summary = this.summaries.get(sessionId)
+    if (summary !== undefined) return sessionListItem(summary, this.labels).title
+    return sessionId
+  }
 
   private visibleSummaries(): SessionSummary[] {
     return this.orderedSummaries().filter((summary) => !this.archives.isArchived(String(summary.sessionId)) && this.inCurrentWorkspace(summary))

--- a/src/gateway/harness-gateway-service.ts
+++ b/src/gateway/harness-gateway-service.ts
@@ -1617,7 +1617,11 @@ export class HarnessGatewayService implements vscode.Disposable {
       const running = args[1] === true
       const summary = this.summaries.get(id)
       if (summary !== undefined) this.summaries.set(id, { ...summary, running, blank: running ? false : summary.blank })
-      if (!running) {
+      if (running) {
+        // A turn starting discards any earlier error (e.g. a background session-activation
+        // failure unrelated to any turn) so it can never be misattributed to this turn's outcome.
+        this.pendingSessionErrors.delete(id)
+      } else {
         this.pendingQueue.forget(id)
         // Host-wide turn/end signal: fires for every session (not just the active one), unlike the
         // session-scoped `turn/end` history event handled in handleFollowFrame().

--- a/src/gateway/harness-gateway-service.ts
+++ b/src/gateway/harness-gateway-service.ts
@@ -109,6 +109,8 @@ export class HarnessGatewayService implements vscode.Disposable {
   private queue: readonly QueuedInboxItem[] = []
   private approvals = new Map<string, PendingApprovalRecord>()
   private questions = new Map<string, PendingQuestionRecord>()
+  /** Latest `api-session/error` per session, consumed by the next `api-session/status(false)` for it. */
+  private readonly pendingSessionErrors = new Map<string, string>()
   private subagentCount = 0
   private subagents: readonly SubagentListEntry[] = []
   private subagentAddress: SubagentAddress | undefined
@@ -1560,25 +1562,10 @@ export class HarnessGatewayService implements vscode.Disposable {
       this.pendingQueue.release(sessionId)
       this.maybeAutoMergeWorktree(sessionId)
       this.metaStore.recordTurnChanges(sessionId, event, this.entries, sessionId === this.activeSessionId, (id) => this.summaries.has(id))
-      if (sessionId !== this.activeSessionId && event.data.reason.kind !== 'aborted') {
-        const title = this.sessionTitle(sessionId)
-        const actionLabel = vscode.l10n.t('Switch to conversation')
-        const isError = event.data.reason.kind === 'error'
-        const errorMsg = isError && 'error' in event.data.reason ? event.data.reason.error.message : ''
-        const message = isError
-          ? vscode.l10n.t('Harness session "{0}" failed: {1}', title, errorMsg)
-          : vscode.l10n.t('Harness session "{0}" finished its turn.', title)
-        const notify = isError ? vscode.window.showErrorMessage : vscode.window.showInformationMessage
-        void notify(message, actionLabel).then((action) => {
-          if (action === actionLabel) {
-            void this.openSession(sessionId)
-              .then(() => vscode.commands.executeCommand('deepseekHarness.chatView.focus'))
-              .catch((err: unknown) => {
-                this.output.appendLine(vscode.l10n.t('[gateway] Failed to switch session: {0}', errorMessage(err)))
-              })
-          }
-        })
-      }
+      // Background-session turn/end notifications are NOT raised here: this handler is only ever invoked
+      // by pumpActiveFollow(), which breaks its loop the moment activeSessionId changes (see the check just
+      // before handleFollowFrame is called) — so `sessionId` below is always the active session already.
+      // The `api-session/status` branch of handleRemoteEvent() is the host-wide signal used instead.
     }
     this.fireChange()
   }
@@ -1630,14 +1617,40 @@ export class HarnessGatewayService implements vscode.Disposable {
       const running = args[1] === true
       const summary = this.summaries.get(id)
       if (summary !== undefined) this.summaries.set(id, { ...summary, running, blank: running ? false : summary.blank })
-      if (!running) this.pendingQueue.forget(id)
+      if (!running) {
+        this.pendingQueue.forget(id)
+        // Host-wide turn/end signal: fires for every session (not just the active one), unlike the
+        // session-scoped `turn/end` history event handled in handleFollowFrame().
+        if (id !== this.activeSessionId) {
+          const errorMsg = this.pendingSessionErrors.get(id)
+          this.pendingSessionErrors.delete(id)
+          const title = this.sessionTitle(id)
+          const actionLabel = vscode.l10n.t('Switch to conversation')
+          const message = errorMsg === undefined
+            ? vscode.l10n.t('Harness session "{0}" finished its turn.', title)
+            : vscode.l10n.t('Harness session "{0}" failed: {1}', title, errorMsg)
+          const notify = errorMsg === undefined ? vscode.window.showInformationMessage : vscode.window.showErrorMessage
+          void notify(message, actionLabel).then((action) => {
+            if (action === actionLabel) {
+              void this.openSession(id)
+                .then(() => vscode.commands.executeCommand('deepseekHarness.chatView.focus'))
+                .catch((err: unknown) => {
+                  this.output.appendLine(vscode.l10n.t('[gateway] Failed to switch session: {0}', errorMessage(err)))
+                })
+            }
+          })
+        }
+      }
     } else if (event === 'api-session/activity') {
       const id = String(args[0] ?? '')
       const updatedAt = typeof args[1] === 'number' ? args[1] : undefined
       const summary = this.summaries.get(id)
       if (summary !== undefined && updatedAt !== undefined) this.summaries.set(id, { ...summary, updatedAt: Math.max(summary.updatedAt, updatedAt) })
     } else if (event === 'api-session/error') {
-      this.output.appendLine(`[agent ${String(args[0] ?? '')}] ${String(args[1] ?? '')}`)
+      const id = String(args[0] ?? '')
+      const message = String(args[1] ?? '')
+      this.pendingSessionErrors.set(id, message)
+      this.output.appendLine(`[agent ${id}] ${message}`)
     } else if (event === 'commands/change' || event === 'agent-preset/selected') {
       void this.refreshCommands()
     } else if (event === 'llm/adapters-updated' || event === 'settings/document-updated') {


### PR DESCRIPTION
Fixes #48

## Problem
1. **Silent drop of approvals/questions on background or switched sessions**: When an agent turn raises a tool-approval request (`approval/asked`) or a structured question (`question/asked`), `HarnessGatewayService` checked `frame.request.sessionId === this.activeSessionId`. If the event originated from a different session (e.g. background run or subagent) or arrived right around a session switch, it was silently ignored and never stored in `this.approvals` / `this.questions`.
2. **Loss of pending interactions on navigation**: Navigating sessions via `selectSession()` or `selectSubagent()` unconditionally cleared both maps (`this.approvals.clear()`, `this.questions.clear()`), dropping active approval cards permanently upon switching tabs.
3. **Lack of awareness for parallel sessions**: When working with multiple sessions in parallel, background sessions finishing their turn or blocked waiting for tool approval had no UI affordance, causing the user to manually cycle through sessions to discover completed or blocked states.

## Solution
1. **Per-session persistence & filtering**:
   - Added `sessionId` field to `PendingApprovalRecord` and `PendingQuestionRecord`.
   - Store all incoming approval/question requests regardless of which session is currently focused.
   - Filter `approvals` and `questions` by `activeSessionId` when constructing the workbench state for rendering.
   - Removed `.clear()` in `selectSession()` and `selectSubagent()` so switching conversations preserves active cards.
   - Cleaned up records on session removal (`api-session/removed`).
2. **Native VS Code notifications for background sessions**:
   - Surface actionable VS Code notifications (`showInformationMessage` / `showWarningMessage`) when:
     - A background session completes its turn (`turn/end`).
     - A background session requires tool approval (`approval/asked`).
     - A background session is waiting for a question answer (`question/asked`).
   - Include a **"Switch to conversation"** button that automatically activates the target session (`openSession`) and focuses the chat view (`deepseekHarness.chatView.focus`).
3. **Localization**:
   - Added Simplified Chinese translations for all new strings in `l10n/bundle.l10n.zh-cn.json`.

## Verification
- `npm run check-types`: 0 errors.
- `npm test`: 51 test suites, 332 passed, 2 skipped (100% pass rate).
- `node esbuild.mjs --production`: clean build.
- Tested and verified in live VS Code extension host:
  - Concurrent multi-session execution.
  - Toast notification appears when background session finishes.
  - "Switch to conversation" button switches active conversation and restores chat view focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Simplified Chinese translations for conversation switching and Harness session status messages.
  - Added notifications when background sessions finish or encounter errors, with an option to switch directly to the relevant conversation.
  - Error notifications now include the reported reason.
  - Approval requests and questions are associated with the correct conversation, including when sessions run in the background.
  - Session titles are displayed when identifying conversations in notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->